### PR TITLE
Implement dashboard and navbar

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -393,3 +393,51 @@ button,
 .notebook-list-item {
   user-select: none;
 }
+/* NavBar styles */
+.navbar {
+  width: 100%;
+  padding: var(--spacing-md);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid #ccc;
+}
+
+.navbar-link {
+  margin-right: var(--spacing-md);
+  text-decoration: none;
+  color: inherit;
+}
+
+.navbar-right button {
+  margin-left: var(--spacing-md);
+}
+
+/* Dashboard notebook list */
+.notebook-list {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  padding: var(--spacing-md);
+}
+
+.notebook-card {
+  border: 1px solid #ccc;
+  border-radius: var(--border-radius);
+  padding: var(--spacing-md);
+  margin-bottom: var(--spacing-md);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  transition: transform 0.2s ease, background 0.2s ease;
+  cursor: pointer;
+}
+
+.notebook-card:hover {
+  transform: scale(1.02);
+  background: var(--bg-highlight);
+}
+
+.add-notebook-btn {
+  margin: var(--spacing-md);
+}

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -1,0 +1,75 @@
+import React, { useState } from 'react';
+import { useRouter } from 'next/router';
+import { useSession } from 'next-auth/react';
+import useSWR from 'swr';
+import NavBar from './NavBar';
+
+const fetcher = (url) => fetch(url).then((res) => res.json());
+
+export default function Dashboard() {
+  const router = useRouter();
+  const { data: session, status } = useSession();
+  const { data: notebooks, mutate } = useSWR(
+    status === 'authenticated' ? '/api/notebooks' : null,
+    fetcher
+  );
+  const [loading, setLoading] = useState(false);
+
+  if (status === 'loading') return <div>Loading...</div>;
+  if (!session) {
+    router.push('/');
+    return null;
+  }
+
+  const handleAdd = async () => {
+    const title = prompt('Notebook title');
+    if (!title) return;
+    setLoading(true);
+    const res = await fetch('/api/notebooks', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title })
+    });
+    if (res.ok) {
+      const newNotebook = await res.json();
+      mutate([newNotebook, ...(notebooks || [])]);
+    }
+    setLoading(false);
+  };
+
+  const handleDelete = async (id) => {
+    if (!confirm('Delete this notebook? This will remove all nested data.')) return;
+    await fetch(`/api/notebooks/${id}`, { method: 'DELETE' });
+    mutate(notebooks.filter((nb) => nb.id !== id));
+  };
+
+  const openNotebook = (id) => router.push(`/notebooks/${id}`);
+
+  return (
+    <div className="dashboard-container">
+      <NavBar />
+      <div className="dashboard-content">
+        <button className="add-notebook-btn" onClick={handleAdd} disabled={loading}>
+          Add Notebook
+        </button>
+        <div className="notebook-list">
+          {notebooks ? (
+            notebooks.map((nb) => (
+              <div key={nb.id} className="notebook-card" onClick={() => openNotebook(nb.id)}>
+                <span className="notebook-title-text">{nb.title}</span>
+                <button
+                  className="notebook-delete-btn"
+                  onClick={(e) => { e.stopPropagation(); handleDelete(nb.id); }}
+                >
+                  🗑
+                </button>
+              </div>
+            ))
+          ) : (
+            <div>Loading...</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -1,40 +1,39 @@
-// src/components/NavBar.jsx
-import React from 'react';
-import { useRouter } from 'next/router';
+import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
 import { signOut } from 'next-auth/react';
-import ThemeSelector from './ThemeSelector';
 
-export default function NavBar({ title, backPath }) {
-  const router = useRouter();
+export default function NavBar() {
+  const [theme, setTheme] = useState('light');
 
-  const handleLogout = async () => {
-    await signOut({ redirect: false });
-    localStorage.removeItem('token');
-    router.push('/');
+  useEffect(() => {
+    const stored = localStorage.getItem('theme') || 'light';
+    setTheme(stored);
+    document.documentElement.setAttribute('data-theme', stored);
+  }, []);
+
+  const toggleTheme = () => {
+    const next = theme === 'light' ? 'dark' : 'light';
+    setTheme(next);
+    document.documentElement.setAttribute('data-theme', next);
+    localStorage.setItem('theme', next);
   };
 
   return (
-    <div style={{
-      width: '100%',
-      padding: '1rem 2rem',
-      display: 'flex',
-      justifyContent: 'space-between',
-      alignItems: 'center',
-      borderBottom: '1px solid #ccc'
-    }}>
-      {backPath ? (
-        <span
-          style={{ fontWeight: 'bold', cursor: 'pointer' }}
-          onClick={() => router.push(backPath)}
-        >
-          {title}
-        </span>
-      ) : (
-        <span style={{ fontWeight: 'bold' }}>{title}</span>
-      )}
-      {/* theme switcher pills */}
-      <ThemeSelector style={{ margin: '0 1rem' }} />
-      <button onClick={handleLogout}>Logout</button>
-    </div>
+    <nav className="navbar">
+      <div className="navbar-left">
+        <Link href="/dashboard" className="navbar-link">Dashboard</Link>
+      </div>
+      <div className="navbar-center">
+        <Link href="#" className="navbar-link">Profile</Link>
+      </div>
+      <div className="navbar-right">
+        <button onClick={toggleTheme} className="theme-toggle-btn">
+          {theme === 'light' ? 'Dark' : 'Light'} Mode
+        </button>
+        <button onClick={() => signOut({ callbackUrl: '/' })} className="logout-btn">
+          Logout
+        </button>
+      </div>
+    </nav>
   );
 }


### PR DESCRIPTION
## Summary
- rebuild Dashboard component to load notebooks and handle add/delete
- recreate NavBar with theme toggle, dashboard/profile links and logout
- extend global styles for NavBar and dashboard notebook cards

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68796489d7c4832da311097947813ddb