### PR TITLE
Fix Next.js export for dashboard page

### DIFF
--- a/pages/dashboard.jsx
+++ b/pages/dashboard.jsx
@@ -1,4 +1,6 @@
 // pages/dashboard.jsx
 import Dashboard from '../src/components/Dashboard';
 
-export default <Dashboard />;
+export default function DashboardPage() {
+  return <Dashboard />;
+}


### PR DESCRIPTION
## Summary
- ensure `pages/dashboard.jsx` exports a React component

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68799497a044832d86fc5dacef3558a6