### PR TITLE
Implement add entity UI and API hooks

### DIFF
--- a/src/components/EntryEditor.jsx
+++ b/src/components/EntryEditor.jsx
@@ -1,24 +1,32 @@
 // src/components/EntryEditor.jsx
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 
-export default function EntryEditor({ entry, onSave, onCancel }) {
-  const [title, setTitle] = useState(entry?.title || '');
-  const [content, setContent] = useState(entry?.content || '');
-
-  // Synchronize local state when entry changes
-  useEffect(() => {
-    if (entry) {
-      setTitle(entry.title);
-      setContent(entry.content);
-    }
-  }, [entry]);
+/**
+ * Reusable modal editor for creating new entities in the notebook tree.
+ * `type` determines which fields are shown and how the save payload is shaped.
+ * parent information (such as subgroupId) is passed through `parent`.
+ */
+export default function EntryEditor({ type, parent, onSave, onCancel }) {
+  const [title, setTitle] = useState(''); // for entries
+  const [content, setContent] = useState('');
+  const [name, setName] = useState(''); // for groups, subgroups, tags
+  const [description, setDescription] = useState('');
 
   const handleSave = () => {
-    if (!title.trim() || !content.trim()) {
-      alert('Title and content cannot be empty.');
+    if (type === 'entry') {
+      if (!title.trim() || !content.trim()) {
+        alert('Title and content cannot be empty.');
+        return;
+      }
+      onSave({ title: title.trim(), content: content.trim(), parent });
       return;
     }
-    onSave({ ...entry, title: title.trim(), content: content.trim() });
+
+    if (!name.trim()) {
+      alert('Name cannot be empty.');
+      return;
+    }
+    onSave({ name: name.trim(), description: description.trim(), parent });
   };
 
   // Close on background click
@@ -33,26 +41,55 @@ export default function EntryEditor({ entry, onSave, onCancel }) {
       <div className="editor-modal-content slide-up">
         <div className="editor-modal-header">
           <h2 className="editor-modal-title">
-            {entry.id ? 'Edit Entry' : 'New Entry'}
+            {type === 'entry' && 'New Entry'}
+            {type === 'group' && 'New Group'}
+            {type === 'subgroup' && 'New Subgroup'}
+            {type === 'tag' && 'New Tag'}
           </h2>
           <button className="editor-modal-close" onClick={onCancel}>
             ×
           </button>
         </div>
         <div className="editor-modal-body">
-          <input
-            className="editor-input-title"
-            type="text"
-            placeholder="Entry Title"
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
-          />
-          <textarea
-            className="editor-textarea-content"
-            placeholder="Write your entry..."
-            value={content}
-            onChange={(e) => setContent(e.target.value)}
-          />
+          {type === 'entry' && (
+            <>
+              <input
+                className="editor-input-title"
+                type="text"
+                placeholder="Entry Title"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+              />
+              <textarea
+                className="editor-textarea-content"
+                placeholder="Write your entry..."
+                value={content}
+                onChange={(e) => setContent(e.target.value)}
+              />
+            </>
+          )}
+          {type !== 'entry' && (
+            <>
+              {parent?.label && (
+                <div style={{ marginBottom: '0.5rem' }}>{parent.label}</div>
+              )}
+              <input
+                className="editor-input-title"
+                type="text"
+                placeholder="Name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+              />
+              {(type === 'group' || type === 'subgroup') && (
+                <textarea
+                  className="editor-textarea-content"
+                  placeholder="Description (optional)"
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                />
+              )}
+            </>
+          )}
         </div>
         <div className="editor-modal-footer">
           <button className="editor-button" onClick={handleSave}>

--- a/src/components/Notebook.jsx
+++ b/src/components/Notebook.jsx
@@ -5,7 +5,7 @@ import { signOut } from 'next-auth/react';
 import EntryEditor from './EntryEditor';
 
 export default function Notebook() {
-  const [showEditor, setShowEditor] = useState(false);
+  const [editorState, setEditorState] = useState({ isOpen: false, type: null, parent: null, index: null });
   const [notebook, setNotebook] = useState(null);
   const [loading, setLoading] = useState(true);
 
@@ -38,20 +38,126 @@ export default function Notebook() {
   }, []);
 
 
-  const handleSave = (entry) => {
-    // TODO: integrate with API
-    console.log('Saved entry', entry);
-    setShowEditor(false);
+  const handleSave = async (data) => {
+    if (!editorState.type) return;
+    try {
+      if (editorState.type === 'entry') {
+        const res = await fetch('/api/entries', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            title: data.title,
+            content: data.content,
+            subgroupId: editorState.parent.subgroupId,
+          }),
+        });
+        if (!res.ok) throw new Error('Failed to create entry');
+        const newEntry = await res.json();
+        setNotebook((prev) => {
+          const groups = prev.groups.map((g) => {
+            if (g.id !== editorState.parent.groupId) return g;
+            return {
+              ...g,
+              subgroups: g.subgroups.map((s) => {
+                if (s.id !== editorState.parent.subgroupId) return s;
+                const entries = [...s.entries];
+                entries.splice(editorState.index + 1, 0, { ...newEntry, tags: [] });
+                return { ...s, entries };
+              }),
+            };
+          });
+          return { ...prev, groups };
+        });
+      } else if (editorState.type === 'subgroup') {
+        const res = await fetch('/api/subgroups', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            name: data.name,
+            description: data.description,
+            groupId: editorState.parent.groupId,
+          }),
+        });
+        if (!res.ok) throw new Error('Failed to create subgroup');
+        const newSub = await res.json();
+        setNotebook((prev) => {
+          const groups = prev.groups.map((g) => {
+            if (g.id !== editorState.parent.groupId) return g;
+            const subgroups = [...g.subgroups];
+            subgroups.splice(editorState.index + 1, 0, { ...newSub, entries: [] });
+            return { ...g, subgroups };
+          });
+          return { ...prev, groups };
+        });
+      } else if (editorState.type === 'group') {
+        const res = await fetch('/api/groups', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            name: data.name,
+            description: data.description,
+            notebookId: notebook.id,
+          }),
+        });
+        if (!res.ok) throw new Error('Failed to create group');
+        const newGroup = await res.json();
+        setNotebook((prev) => {
+          const groups = [...prev.groups];
+          groups.splice(editorState.index + 1, 0, { ...newGroup, subgroups: [] });
+          return { ...prev, groups };
+        });
+      } else if (editorState.type === 'tag') {
+        const tagRes = await fetch('/api/tags', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: data.name, notebookId: notebook.id }),
+        });
+        if (!tagRes.ok) throw new Error('Failed to create tag');
+        const newTag = await tagRes.json();
+        const entryRes = await fetch(`/api/entries/${editorState.parent.entryId}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            tagIds: [...editorState.parent.tagIds, newTag.id],
+          }),
+        });
+        if (!entryRes.ok) throw new Error('Failed to attach tag');
+        const updatedEntry = await entryRes.json();
+        setNotebook((prev) => {
+          const groups = prev.groups.map((g) => {
+            if (g.id !== editorState.parent.groupId) return g;
+            return {
+              ...g,
+              subgroups: g.subgroups.map((s) => {
+                if (s.id !== editorState.parent.subgroupId) return s;
+                const entries = s.entries.map((e) =>
+                  e.id === editorState.parent.entryId ? { ...updatedEntry } : e
+                );
+                return { ...s, entries };
+              }),
+            };
+          });
+          return { ...prev, groups };
+        });
+      }
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setEditorState({ isOpen: false, type: null, parent: null, index: null });
+    }
   };
 
   const handleCancel = () => {
-    setShowEditor(false);
+    setEditorState({ isOpen: false, type: null, parent: null, index: null });
+  };
+
+  const openEditor = (type, parent, index) => {
+    setEditorState({ isOpen: true, type, parent, index });
   };
 
   return (
     <div style={{ padding: '2rem' }}>
       <h1>{notebook ? notebook.title : 'Notebook'}</h1>
-      <button onClick={() => setShowEditor(true)}>Add Entry</button>
       <button onClick={() => signOut({ redirect: false })} style={{ marginLeft: '1rem' }}>
         Logout
       </button>
@@ -60,17 +166,17 @@ export default function Notebook() {
 
       {!loading && notebook && (
         <div style={{ marginTop: '2rem' }}>
-          {notebook.groups.map(group => (
+          {notebook.groups.map((group, gIdx) => (
             <div>
               <div key={group.id} style={{ marginBottom: '1rem' }}>
                 <h2>{group.name}</h2>
                 <div style={{ paddingLeft: '1rem' }}>
-                  {group.subgroups.map(sub => (
+                  {group.subgroups.map((sub, sIdx) => (
                     <div>
                       <div key={sub.id} style={{ marginBottom: '0.5rem' }}>
                         <h3>{sub.name}</h3>
                         <div style={{ paddingLeft: '1rem' }}>
-                          {sub.entries.map(entry => (
+                          {sub.entries.map((entry, eIdx) => (
                             <div>
                               <div key={entry.id} style={{ marginBottom: '0.25rem' }}>
                                 <h4>{entry.title}</h4>
@@ -84,19 +190,49 @@ export default function Notebook() {
                                     ))}
                                   </div>
                                 )}
-                                {entry && <button onClick={() => setShowEditor(true)}>Add Tag</button>}
+                                {entry && (
+                                  <button
+                                    onClick={() =>
+                                      openEditor(
+                                        'tag',
+                                        {
+                                          entryId: entry.id,
+                                          subgroupId: sub.id,
+                                          groupId: group.id,
+                                          tagIds: entry.tags.map(t => t.id),
+                                          label: `Entry: ${entry.title}`,
+                                        },
+                                        entry.tags.length - 1
+                                      )
+                                    }
+                                  >
+                                    Add Tag
+                                  </button>
+                                )}
                               </div>
-                              {sub && <button onClick={() => setShowEditor(true)}>Add Entry</button>}
+                              {sub && (
+                                <button
+                                  onClick={() =>
+                                    openEditor(
+                                      'entry',
+                                      { subgroupId: sub.id, groupId: group.id, label: `Subgroup: ${sub.name}` },
+                                      eIdx
+                                    )
+                                  }
+                                >
+                                  Add Entry
+                                </button>
+                              )}
                             </div>
                           ))}
                         </div>
                       </div>
-                      <button onClick={() => setShowEditor(true)}>Add Subgroup</button>
+                      <button onClick={() => openEditor('subgroup', { groupId: group.id, label: `Group: ${group.name}` }, sIdx)}>Add Subgroup</button>
                     </div>
                   ))}
                 </div>
               </div>
-              <button onClick={() => setShowEditor(true)}>Add Group</button>
+              <button onClick={() => openEditor('group', { label: 'Notebook Root' }, gIdx)}>Add Group</button>
 
             </div>
           ))}
@@ -104,9 +240,8 @@ export default function Notebook() {
       )}
 
 
-      <button onClick={() => setShowEditor(true)}>Add Entry</button>
-      {showEditor && (
-        <EntryEditor onSave={handleSave} onCancel={handleCancel} />
+      {editorState.isOpen && (
+        <EntryEditor type={editorState.type} parent={editorState.parent} onSave={handleSave} onCancel={handleCancel} />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- enhance EntryEditor to support multiple entity types
- rework Notebook to track editor state and perform POST requests for new groups, subgroups, entries, and tags

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68838bac9248832dafceacd2453caa77