### PR TITLE
Implement type-based modal sizing

### DIFF
--- a/src/components/EntryEditor.jsx
+++ b/src/components/EntryEditor.jsx
@@ -36,9 +36,12 @@ export default function EntryEditor({ type, parent, onSave, onCancel }) {
     }
   };
 
+  const overlayClass = `editor-modal-overlay ${type === 'entry' ? 'fullscreen' : 'popup'}`;
+  const contentClass = `editor-modal-content ${type === 'entry' ? 'fullscreen' : 'popup'} slide-up`;
+
   return (
-    <div className="editor-modal-overlay" onClick={handleOverlayClick}>
-      <div className="editor-modal-content slide-up">
+    <div className={overlayClass} onClick={handleOverlayClick}>
+      <div className={contentClass}>
         <div className="editor-modal-header">
           <h2 className="editor-modal-title">
             {type === 'entry' && 'New Entry'}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -54,20 +54,34 @@ body {
   left: 0;
   right: 0;
   bottom: 0;
-  /* background: rgba(0, 0, 0, 0.5); darkened background for non full width modal*/
-
-  background: rgba(255, 255, 255, 1);
   display: flex;
   justify-content: center;
   align-items: center;
   z-index: 1000;
 }
 
+.editor-modal-overlay.popup {
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.editor-modal-overlay.fullscreen {
+  background: rgba(255, 255, 255, 1);
+}
+
 .editor-modal-content {
   background: #fff;
   color: #000;
+}
+
+.editor-modal-content.popup {
+  padding: 1em;
+  border-radius: 1em;
+  width: 90%;
+  max-width: 500px;
+}
+
+.editor-modal-content.fullscreen {
   padding: 10rem;
-  /* border-radius: 2rem; */
   height: 100%;
   width: 100%;
   max-width: 100vw;


### PR DESCRIPTION
## Summary
- show full-screen editor overlay when editing entries
- show dark popup overlay for groups, subgroups, and tags
- add CSS classes for popup/fullscreen modals

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_688547d51318832d949ca909f1bb2126