### PR TITLE
Add delete functions and tag removal

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -168,10 +168,18 @@ body {
 }
 
 .tag {
-  display: inline-block;
   padding: 0.25em 0.5em;
   border-radius: 0.5em;
   background: #ddd;
   margin-right: 0.25em;
   margin-bottom: 0.25em;
+  cursor: pointer;
+  user-select: none;
+  display: inline-flex;
+  align-items: center;
+}
+
+.tag .close-icon {
+  margin-right: 0.25em;
+  font-weight: bold;
 }


### PR DESCRIPTION
## Summary
- allow deleting groups, subgroups and entries from Notebook
- make tags clickable to remove them
- only show delete buttons when an entity has no children
- tweak tag styling for clickable removal

## Testing
- `npx eslint .` *(fails: 22 errors)*
- `npx next build`


------
https://chatgpt.com/codex/tasks/task_b_68854c9f3db8832d8ab8a7d6ff1f4756