### PR TITLE
Improve modal input spacing

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -80,7 +80,7 @@ body {
 }
 
 .editor-modal-content.popup {
-  padding: 1em;
+  padding: 1rem;
   border-radius: 1em;
   width: 100%;
   max-width: 500px;
@@ -88,14 +88,40 @@ body {
 }
 
 .editor-modal-content.fullscreen {
-  padding: 10rem;
+  padding: 2rem;
   height: 100%;
   width: 100%;
   max-width: 100vw;
 }
 
+.editor-modal-content.fullscreen .editor-modal-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.editor-modal-content.fullscreen .editor-input-title {
+  width: 100%;
+  margin-bottom: 1rem;
+}
+
+.editor-modal-content.fullscreen .editor-textarea-content {
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+  height: auto;
+  padding: 2rem;
+  resize: none;
+  overflow-y: auto;
+  scrollbar-width: none;
+}
+
+.editor-modal-content.fullscreen .editor-textarea-content::-webkit-scrollbar {
+  display: none;
+}
+
 .editor-modal-content.notebook {
-  padding: 1em;
+  padding: 1rem;
   border-radius: 1em;
   width: 800px;
   max-width: 800px;
@@ -106,7 +132,7 @@ body {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 1em;
+  margin-bottom: 1rem;
 }
 
 .editor-modal-title {
@@ -128,30 +154,37 @@ body {
 
 .editor-modal-body input,
 .editor-modal-body textarea {
-  width: auto;
-  padding: 0.5em;
-  border-radius: 0.5em;
+  width: 100%;
+  padding: 0.5rem;
+  border-radius: 0.5rem;
   border: 1px solid #ccc;
   font-family: inherit;
+  box-sizing: border-box;
 }
 
 .editor-modal-body input {
   height: 3em;
-  /* padding: 1em; */
-  width: 100%;
-  margin-bottom: 1em;
+  margin-bottom: 1rem;
 }
 
 .editor-modal-body textarea {
   height: 3em;
-  padding: 1em;
-  margin-bottom: 1em;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  resize: none;
+}
+
+.editor-modal-body input:focus,
+.editor-modal-body textarea:focus {
+  outline: none;
+  box-shadow: none;
 }
 
 .editor-modal-footer {
   display: flex;
   justify-content: flex-end;
   gap: 0.5em;
+  margin-top: 1rem;
 }
 
 .editor-button {


### PR DESCRIPTION
## Summary
- tighten padding in popup modals
- make full‑screen modals use flexible body layout
- ensure inputs fill rows with consistent margins
- remove scrollbar and resize handle from textarea
- hide focus outlines

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68864309ada0832db8c7db1479f222cd