### PR TITLE
Fix null id error on save

### DIFF
--- a/src/components/EntryEditor.jsx
+++ b/src/components/EntryEditor.jsx
@@ -43,7 +43,7 @@ export default function EntryEditor({
         content: content.trim(),
         parent,
         mode,
-        id: initialData.id,
+        id: safeData.id,
       });
       return;
     }
@@ -57,7 +57,7 @@ export default function EntryEditor({
       description: description.trim(),
       parent,
       mode,
-      id: initialData.id,
+      id: safeData.id,
     });
   };
 


### PR DESCRIPTION
## Summary
- avoid reading `initialData.id` when creating new entries

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688688ce4f60832da748688c461223fd