### PR TITLE
Move delete actions into EntryEditor

### DIFF
--- a/src/components/EntryEditor.jsx
+++ b/src/components/EntryEditor.jsx
@@ -11,6 +11,7 @@ export default function EntryEditor({
   parent,
   onSave,
   onCancel,
+  onDelete = null,
   initialData = {},
   mode = 'create',
 }) {
@@ -75,6 +76,13 @@ export default function EntryEditor({
     type === 'entry' ? 'fullscreen' : type === 'notebook' ? 'notebook' : 'popup'
   } slide-up`;
 
+  const handleDelete = () => {
+    if (onDelete) {
+      onDelete();
+    }
+    onCancel();
+  };
+
   return (
     <div className={overlayClass} onClick={handleOverlayClick}>
       <div className={contentClass}>
@@ -137,6 +145,11 @@ export default function EntryEditor({
           <button className="editor-button" onClick={handleSave}>
             Save
           </button>
+          {mode === 'edit' && onDelete && (
+            <button className="editor-button danger" onClick={handleDelete}>
+              Delete
+            </button>
+          )}
           <button className="editor-button secondary" onClick={onCancel}>
             Cancel
           </button>

--- a/src/components/Notebook.jsx
+++ b/src/components/Notebook.jsx
@@ -13,6 +13,7 @@ export default function Notebook() {
     index: null,
     item: null,
     mode: 'create',
+    onDelete: null,
   });
   const [notebook, setNotebook] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -226,6 +227,7 @@ export default function Notebook() {
         index: null,
         item: null,
         mode: 'create',
+        onDelete: null,
       });
     }
   };
@@ -238,11 +240,19 @@ export default function Notebook() {
       index: null,
       item: null,
       mode: 'create',
+      onDelete: null,
     });
   };
 
-  const openEditor = (type, parent, index, item = null, mode = 'create') => {
-    setEditorState({ isOpen: true, type, parent, index, item, mode });
+  const openEditor = (
+    type,
+    parent,
+    index,
+    item = null,
+    mode = 'create',
+    onDelete = null
+  ) => {
+    setEditorState({ isOpen: true, type, parent, index, item, mode, onDelete });
   };
 
   const toggleGroup = (group) => {
@@ -408,7 +418,14 @@ export default function Notebook() {
                     className="edit-icon"
                     onClick={(e) => {
                       e.stopPropagation();
-                      openEditor('group', { groupId: group.id }, null, group, 'edit');
+                      openEditor(
+                        'group',
+                        { groupId: group.id },
+                        null,
+                        group,
+                        'edit',
+                        () => handleDeleteGroup(group.id)
+                      );
                     }}
                   >
                     ✎
@@ -426,16 +443,7 @@ export default function Notebook() {
                   Collapse
                 </button>
               )} */}
-              {group.subgroups.length === 0 && (
-                <button
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    handleDeleteGroup(group.id);
-                  }}
-                >
-                  Delete
-                </button>
-              )}
+
 
               {expandedGroups.includes(group.id) && (
                 <div>
@@ -452,7 +460,8 @@ export default function Notebook() {
                                 { groupId: group.id, subgroupId: sub.id },
                                 null,
                                 sub,
-                                'edit'
+                                'edit',
+                                () => handleDeleteSubgroup(group.id, sub.id)
                               );
                             }}
                           >
@@ -471,16 +480,7 @@ export default function Notebook() {
                           Collapse
                         </button>
                       )} */}
-                      {sub.entries.length === 0 && (
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            handleDeleteSubgroup(group.id, sub.id);
-                          }}
-                        >
-                          Delete
-                        </button>
-                      )}
+
 
                       {expandedSubgroups.includes(sub.id) && (
                         <div>
@@ -500,7 +500,13 @@ export default function Notebook() {
                                       },
                                       null,
                                       entry,
-                                      'edit'
+                                      'edit',
+                                      () =>
+                                        handleDeleteEntry(
+                                          group.id,
+                                          sub.id,
+                                          entry.id
+                                        )
                                     );
                                   }}
                                 >
@@ -533,14 +539,7 @@ export default function Notebook() {
                                       ))}
                                     </div>
                                   )}
-                                  <button
-                                    onClick={(e) => {
-                                      e.stopPropagation();
-                                      handleDeleteEntry(group.id, sub.id, entry.id);
-                                    }}
-                                  >
-                                    Delete
-                                  </button>
+
                                   <button
                                     onClick={(e) => {
                                       e.stopPropagation();
@@ -615,6 +614,7 @@ export default function Notebook() {
           parent={editorState.parent}
           onSave={handleSave}
           onCancel={handleCancel}
+          onDelete={editorState.onDelete}
           initialData={editorState.item}
           mode={editorState.mode}
         />

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -212,6 +212,12 @@ body {
   background: #eee;
 }
 
+.editor-button.danger {
+  background: #f8d7da;
+  border-color: #f5c2c7;
+  color: #842029;
+}
+
 .slide-up {
   animation: slideUp 0.3s ease-out;
 }


### PR DESCRIPTION
## Summary
- expose `onDelete` prop in `EntryEditor` and add Delete button
- style new danger button
- manage delete handler in `Notebook` and pass to `EntryEditor`
- remove inline Delete buttons from Notebook cards

## Testing
- `npm exec eslint .` *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@eslint/js')*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68868c8454e0832db002d5b55c567104