### PR TITLE
Add profile menu for logout

### DIFF
--- a/src/components/Notebook.jsx
+++ b/src/components/Notebook.jsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { signOut } from 'next-auth/react';
 
 
 import EntryEditor from './EntryEditor';
@@ -402,9 +401,6 @@ export default function Notebook() {
         )}
         {notebook ? notebook.title : 'Notebook'}
       </h1>
-      <button onClick={() => signOut({ redirect: false })} style={{ marginLeft: '1rem' }}>
-        Logout
-      </button>
 
       {loading && <p>Loading...</p>}
 

--- a/src/components/NotebookController.jsx
+++ b/src/components/NotebookController.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { signOut } from 'next-auth/react';
 import EntryEditor from './EntryEditor';
 
 export default function NotebookController({ onSelect }) {
@@ -50,16 +51,24 @@ export default function NotebookController({ onSelect }) {
 
   return (
     <div className="notebook-controller">
-      <select value={selected} onChange={handleChange}>
-        {notebooks.map((nb) => (
-          <option key={nb.id} value={nb.id}>
-            {nb.title}
-          </option>
-        ))}
-      </select>
-      <button onClick={() => setShowModal(true)} style={{ marginLeft: '0.5rem' }}>
-        Add New
-      </button>
+      <div className="controller-left">
+        <select value={selected} onChange={handleChange}>
+          {notebooks.map((nb) => (
+            <option key={nb.id} value={nb.id}>
+              {nb.title}
+            </option>
+          ))}
+        </select>
+        <button onClick={() => setShowModal(true)} style={{ marginLeft: '0.5rem' }}>
+          Add New
+        </button>
+      </div>
+      <div className="profile-menu-container">
+        <button className="profile-icon">&#128100;</button>
+        <div className="profile-menu">
+          <button onClick={() => signOut({ redirect: false })}>Logout</button>
+        </div>
+      </div>
       {showModal && (
         <EntryEditor
           type="notebook"

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -255,3 +255,43 @@ body {
   margin-right: 0.5rem;
   cursor: pointer;
 }
+
+.notebook-controller {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.controller-left {
+  display: flex;
+  align-items: center;
+}
+
+.profile-menu-container {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.profile-icon {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 1.5rem;
+}
+
+.profile-menu {
+  display: none;
+  position: absolute;
+  right: 0;
+  top: 100%;
+  background: #fff;
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+  border-radius: 0.5rem;
+  z-index: 100;
+}
+
+.profile-menu-container:hover .profile-menu {
+  display: block;
+}


### PR DESCRIPTION
## Summary
- remove logout button from `Notebook`
- add profile icon with logout flyout menu in `NotebookController`
- style new controller layout and profile menu

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68868ffa370c832d8f70c677fb3aeafa