### PR TITLE
Add dark mode support with settings page

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -2,11 +2,14 @@
 import { SessionProvider } from 'next-auth/react';
 import '../src/styles/main.css';
 import 'antd/dist/reset.css';
+import ThemeProvider from '../src/components/ThemeProvider';
 
 export default function App({ Component, pageProps }) {
   return (
     <SessionProvider session={pageProps.session}>
-      <Component {...pageProps} />
+      <ThemeProvider>
+        <Component {...pageProps} />
+      </ThemeProvider>
     </SessionProvider>
   );
 }

--- a/pages/settings.js
+++ b/pages/settings.js
@@ -1,0 +1,5 @@
+import Settings from '../src/components/Settings';
+
+export default function SettingsPage() {
+  return <Settings />;
+}

--- a/src/components/NotebookController.jsx
+++ b/src/components/NotebookController.jsx
@@ -72,6 +72,7 @@ export default function NotebookController({ onSelect, showEdits, onToggleEdits 
       <div className="profile-menu-container">
         <button className="profile-icon">&#128100;</button>
         <div className="profile-menu">
+          <a href="/settings" style={{ display: 'block', marginBottom: '0.5rem' }}>Settings</a>
           <button onClick={() => signOut({ redirect: false })}>Logout</button>
         </div>
       </div>

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -1,0 +1,17 @@
+import React, { useContext } from 'react';
+import { Switch } from 'antd';
+import { ThemeContext } from './ThemeProvider';
+
+export default function Settings() {
+  const { darkMode, toggleTheme } = useContext(ThemeContext);
+
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h2>Settings</h2>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+        <span>Dark Mode</span>
+        <Switch checked={darkMode} onChange={toggleTheme} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/ThemeProvider.jsx
+++ b/src/components/ThemeProvider.jsx
@@ -1,0 +1,49 @@
+import React, { createContext, useEffect, useState } from 'react';
+import { ConfigProvider, theme as antdTheme } from 'antd';
+
+export const ThemeContext = createContext({
+  darkMode: false,
+  toggleTheme: () => {},
+});
+
+export default function ThemeProvider({ children }) {
+  const [darkMode, setDarkMode] = useState(false);
+
+  // Initialize theme from localStorage or matchMedia
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const stored = localStorage.getItem('theme');
+    if (stored) {
+      setDarkMode(stored === 'dark');
+    } else {
+      const prefersDark = window.matchMedia &&
+        window.matchMedia('(prefers-color-scheme: dark)').matches;
+      setDarkMode(prefersDark);
+    }
+  }, []);
+
+  // Persist theme and update body attribute
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    localStorage.setItem('theme', darkMode ? 'dark' : 'light');
+    document.body.setAttribute('data-theme', darkMode ? 'dark' : 'light');
+  }, [darkMode]);
+
+  const toggleTheme = () => {
+    setDarkMode((prev) => !prev);
+  };
+
+  return (
+    <ConfigProvider
+      theme={{
+        algorithm: darkMode
+          ? antdTheme.darkAlgorithm
+          : antdTheme.defaultAlgorithm,
+      }}
+    >
+      <ThemeContext.Provider value={{ darkMode, toggleTheme }}>
+        {children}
+      </ThemeContext.Provider>
+    </ConfigProvider>
+  );
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -386,3 +386,23 @@ button:hover {
   border-left: 3px solid #000;
   border-radius: 0 2rem 2rem 0;
 }
+
+/* Basic dark mode styles */
+body[data-theme='dark'] {
+  background: #141414;
+  color: #fff;
+}
+
+body[data-theme='dark'] .profile-menu,
+body[data-theme='dark'] .group-header,
+body[data-theme='dark'] .subgroup-header,
+body[data-theme='dark'] .entry-header,
+body[data-theme='dark'] .group-card,
+body[data-theme='dark'] .subgroup-card,
+body[data-theme='dark'] .entry-card,
+body[data-theme='dark'] .add-group,
+body[data-theme='dark'] .add-subgroup,
+body[data-theme='dark'] .add-entry {
+  background-color: #1f1f1f;
+  color: #fff;
+}


### PR DESCRIPTION
## Summary
- wrap app with new `ThemeProvider` that applies AntD dark/light theme
- add `Settings` component and `/settings` page
- enable a profile menu link to `/settings`
- persist selected theme to `localStorage`
- add basic dark mode styling

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6887f1558608832dacdc45696c0638af