### PR TITLE
Add arrow icons and slide animation

### DIFF
--- a/src/components/Notebook.jsx
+++ b/src/components/Notebook.jsx
@@ -468,9 +468,8 @@ export default function Notebook() {
                   </button>
                 )}
               </div>
-              {expandedGroups.includes(group.id) && (
-                <div>
-                  {group.subgroups.map((sub) => (
+              <div className={`group-children collapsible ${expandedGroups.includes(group.id) ? 'open' : ''}`}> 
+                {group.subgroups.map((sub) => (
                     <div key={sub.id} className="subgroup-card">
                       <div
                         className={`subgroup-header interactive ${expandedSubgroups.includes(sub.id) ? 'open' : ''}`}
@@ -501,10 +500,9 @@ export default function Notebook() {
                           </button>
                         )}
                       </div>
-                      {expandedSubgroups.includes(sub.id) && (
-                        <div>
-                          {sub.entries.map((entry) => (
-                            <div key={entry.id} className="entry-card">
+                      <div className={`subgroup-children collapsible ${expandedSubgroups.includes(sub.id) ? 'open' : ''}`}> 
+                        {sub.entries.map((entry) => (
+                            <div key={entry.id} className={`entry-card ${expandedEntries.includes(entry.id) ? 'open' : ''}`}>
                               <div
                                 className="entry-header interactive"
                                 role="button"
@@ -515,81 +513,80 @@ export default function Notebook() {
                                 }}
                               >
                                 <h4 class="entry-card-title">{entry.title}</h4>
-                                {!expandedEntries.includes(entry.id) && (
-                                  <div class="entry-card-content">
+                                <div class="entry-card-content">
+                                  {expandedEntries.includes(entry.id) ? (
+                                    entry.content
+                                  ) : (
                                     <p>{entry.content.slice(0, 40)}...</p>
+                                  )}
+                                </div>
+                              </div>
+                              <div className={`entry-details collapsible ${expandedEntries.includes(entry.id) ? 'open' : ''}`}>
+                                {entry.tags.length > 0 && (
+                                  <div>
+                                    {entry.tags.map((tag) => (
+                                      <div
+                                        key={tag.id}
+                                        className="tag"
+                                        onClick={() =>
+                                          handleRemoveTag(
+                                            group.id,
+                                            sub.id,
+                                            entry.id,
+                                            tag.id,
+                                            entry.tags.map((t) => t.id)
+                                          )
+                                        }
+                                      >
+                                        <span className="close-icon">×</span>
+                                        {tag.name}
+                                      </div>
+                                    ))}
                                   </div>
                                 )}
-                                {expandedEntries.includes(entry.id) && (
-                                  <>
-                                    <div class="entry-card-content">{entry.content}</div>
-                                    {entry.tags.length > 0 && (
-                                      <div>
-                                        {entry.tags.map((tag) => (
-                                          <div
-                                            key={tag.id}
-                                            className="tag"
-                                            onClick={() =>
-                                              handleRemoveTag(
-                                                group.id,
-                                                sub.id,
-                                                entry.id,
-                                                tag.id,
-                                                entry.tags.map((t) => t.id)
-                                              )
-                                            }
-                                          >
-                                            <span className="close-icon">×</span>
-                                            {tag.name}
-                                          </div>
-                                        ))}
-                                      </div>
-                                    )}
-                                    <button
-                                      style={{ marginRight: "1rem" }}
-                                      onClick={(e) => {
-                                        e.stopPropagation();
-                                        openEditor(
-                                          'tag',
-                                          {
-                                            entryId: entry.id,
-                                            subgroupId: sub.id,
-                                            groupId: group.id,
-                                            tagIds: entry.tags.map((t) => t.id),
-                                            label: `Entry: ${entry.title}`,
-                                          },
-                                          entry.tags.length - 1
-                                        );
-                                      }}
-                                    >
-                                      Add Tag
-                                    </button>
-                                    <button
-                                      onClick={(e) => {
-                                        e.stopPropagation();
-                                        openEditor(
-                                          'entry',
-                                          {
-                                            subgroupId: sub.id,
-                                            groupId: group.id,
-                                            entryId: entry.id,
-                                          },
-                                          null,
-                                          entry,
-                                          'edit',
-                                          () =>
-                                            handleDeleteEntry(
-                                              group.id,
-                                              sub.id,
-                                              entry.id
-                                            )
-                                        );
-                                      }}
-                                    >
-                                      Edit
-                                    </button>
-                                  </>
-                                )}
+                                <button
+                                  style={{ marginRight: "1rem" }}
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    openEditor(
+                                      'tag',
+                                      {
+                                        entryId: entry.id,
+                                        subgroupId: sub.id,
+                                        groupId: group.id,
+                                        tagIds: entry.tags.map((t) => t.id),
+                                        label: `Entry: ${entry.title}`,
+                                      },
+                                      entry.tags.length - 1
+                                    );
+                                  }}
+                                >
+                                  Add Tag
+                                </button>
+                                <button
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    openEditor(
+                                      'entry',
+                                      {
+                                        subgroupId: sub.id,
+                                        groupId: group.id,
+                                        entryId: entry.id,
+                                      },
+                                      null,
+                                      entry,
+                                      'edit',
+                                      () =>
+                                        handleDeleteEntry(
+                                          group.id,
+                                          sub.id,
+                                          entry.id
+                                        )
+                                    );
+                                  }}
+                                >
+                                  Edit
+                                </button>
                               </div>
                             </div>
                           ))}
@@ -609,7 +606,6 @@ export default function Notebook() {
                             Add Entry
                           </div>
                         </div>
-                      )}
                     </div>
                   ))}
                   <div
@@ -628,7 +624,6 @@ export default function Notebook() {
                     Add Subgroup
                   </div>
                 </div>
-              )}
             </div>
           ))}
           <div

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,4 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+Symbols&display=swap');
 
 body {
   font-family: 'IBM Plex Mono', 'Cutive Mono', monospace;
@@ -68,6 +69,27 @@ body {
   font-size: 1.75rem;
   font-weight: 300;
   background-color: #fff;
+}
+
+/* arrow icons for expandable items */
+.group-title::before,
+.subgroup-title::before,
+.entry-card-content::before {
+  font-family: 'Noto Sans Symbols', sans-serif;
+  margin-right: 0.5rem;
+  display: inline-block;
+}
+
+.group-card .group-title::before,
+.subgroup-header .subgroup-title::before,
+.entry-header .entry-card-content::before {
+  content: '▸';
+}
+
+.group-card.open .group-title::before,
+.subgroup-header.open .subgroup-title::before,
+.entry-card.open .entry-card-content::before {
+  content: '▾';
 }
 
 .entry-card {
@@ -414,4 +436,15 @@ body[data-theme='dark'] .add-subgroup,
 body[data-theme='dark'] .add-entry {
   background-color: #1f1f1f;
   color: #fff;
+}
+
+/* smooth expand/collapse */
+.collapsible {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.3s ease;
+}
+
+.collapsible.open {
+  max-height: 1000px;
 }


### PR DESCRIPTION
## Summary
- import Noto Sans Symbols for dingbat style arrows
- show right/down arrows for group, subgroup, and entry content
- add collapsible containers with smooth slide transitions
- restructure Notebook component to use new collapsible sections

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6888ce319c6c832d96989dfafcf5b5e6