### PR TITLE
Implement progressive sticky headers

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -41,6 +41,10 @@ body {
   justify-content: flex-end;
   padding: 2rem;
   margin-bottom: 0rem;
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  transition: transform 0.15s ease, opacity 0.15s ease;
 }
 
 .group-title {
@@ -63,6 +67,9 @@ body {
   border: none;
   background-color: #fff;
   margin-bottom: 0rem;
+  position: sticky;
+  top: 0;
+  z-index: 30;
 }
 
 .subgroup-title {
@@ -515,6 +522,11 @@ body[data-theme='dark'] .add-subgroup,
 body[data-theme='dark'] .add-entry {
   background-color: #1f1f1f;
   color: #fff;
+}
+
+.fade-out {
+  transform: translateY(-100%);
+  opacity: 0;
 }
 
 /* smooth expand/collapse */


### PR DESCRIPTION
## Summary
- make group and subgroup headers sticky via CSS
- fade group header out when a subgroup header reaches the top
- track scroll position in Notebook component so only one header stays pinned

## Testing
- `npx eslint src/components/Notebook.jsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688a3c6e6c04832dab35181a87af8319