### PR TITLE
Fix toolbar animation and selection persistence

### DIFF
--- a/src/components/EntryEditor.jsx
+++ b/src/components/EntryEditor.jsx
@@ -143,7 +143,13 @@ export default function EntryEditor({
     if (range && range.length > 0) {
       setToolbarVisible(true);
     } else {
-      setToolbarVisible(false);
+      const activeInToolbar =
+        typeof document !== 'undefined' &&
+        document.activeElement &&
+        document.activeElement.closest('.ql-toolbar');
+      if (!activeInToolbar) {
+        setToolbarVisible(false);
+      }
     }
   };
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -285,19 +285,14 @@ body {
   font-family: 'IBM Plex Mono', 'Cutive Mono', monospace;
   text-align: center;
   height: 40px;
+  transition: transform 0.2s ease-in-out, opacity 0.2s ease-in-out;
+  transform: translateY(0);
 }
-
-
 
 .editor-modal-content.fullscreen .toolbar-hidden .ql-toolbar {
-  display: none;
-  height: 40px;
-}
-
-.editor-modal-content.fullscreen .toolbar-hidden .ql-toolbar::before {
-  content: "";
-  min-height: 40px;
-  height: 40px;
+  transform: translateY(-100%);
+  opacity: 0;
+  pointer-events: none;
 }
 
 .editor-modal-content.notebook {


### PR DESCRIPTION
## Summary
- animate Quill toolbar instead of fully removing it
- keep toolbar visible when interacting with it so size options work

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688ad3a7e668832d8179a8d5c14ba0de