### PR TITLE
Fix Quill dropdown visibility and header styling

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -636,3 +636,23 @@ body[data-theme='light'] .navbar {
 .collapsible.open::-webkit-scrollbar {
   display: none;
 }
+
+/* Ensure Quill toolbar dropdowns have visible backgrounds */
+.ql-toolbar .ql-picker-options {
+  background-color: #fff;
+  color: #000;
+}
+
+body[data-theme='dark'] .ql-toolbar .ql-picker-options {
+  background-color: #1f1f1f;
+  color: #fff;
+}
+
+/* Provide basic header styling inside the editor */
+.ql-editor h1 {
+  font-size: 2em;
+}
+
+.ql-editor h2 {
+  font-size: 1.5em;
+}


### PR DESCRIPTION
## Summary
- ensure Quill picker dropdowns use solid backgrounds for visibility
- style h1 and h2 within the Quill editor so header selections visibly change text size

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_688b72fd9454832d87857d88cf157cd3