### PR TITLE
Fix Quill dropdown click area

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -313,7 +313,8 @@ body {
 .editor-header-wrapper {
   position: relative;
   height: 4rem;
-  overflow: hidden;
+  /* allow Quill dropdowns to extend beyond the header wrapper */
+  overflow: visible;
 }
 
 .editor-header-wrapper.fullscreen {
@@ -635,4 +636,24 @@ body[data-theme='light'] .navbar {
 
 .collapsible.open::-webkit-scrollbar {
   display: none;
+}
+
+/* Ensure Quill toolbar dropdowns have visible backgrounds */
+.ql-toolbar .ql-picker-options {
+  background-color: #fff;
+  color: #000;
+}
+
+body[data-theme='dark'] .ql-toolbar .ql-picker-options {
+  background-color: #1f1f1f;
+  color: #fff;
+}
+
+/* Provide basic header styling inside the editor */
+.ql-editor h1 {
+  font-size: 2em;
+}
+
+.ql-editor h2 {
+  font-size: 1.5em;
 }


### PR DESCRIPTION
## Summary
- allow Quill dropdowns to extend beyond the header wrapper so the entire option area is clickable

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688b72fd9454832d87857d88cf157cd3