### PR TITLE
Fix neon workflow outputs to enable branch deletion

### DIFF
--- a/.github/workflows/neon_workflow.yml
+++ b/.github/workflows/neon_workflow.yml
@@ -25,8 +25,8 @@ jobs:
   create_neon_branch:
     name: Create Neon Branch
     outputs:
-      db_url: ${{ steps.create_neon_branch_encode.outputs.db_url }}
-      db_url_with_pooler: ${{ steps.create_neon_branch_encode.outputs.db_url_with_pooler }}
+      db_url: ${{ steps.create_neon_branch.outputs.db_url }}
+      db_url_with_pooler: ${{ steps.create_neon_branch.outputs.db_url_with_pooler }}
     needs: setup
     if: |
       github.event_name == 'pull_request' && (


### PR DESCRIPTION
## Summary
- fix output names in Neon workflow

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688bb223b49c832db0c4e7a79de9bc26