### PR TITLE
Add floating title and autosave

### DIFF
--- a/src/components/Notebook.jsx
+++ b/src/components/Notebook.jsx
@@ -93,6 +93,7 @@ export default function Notebook() {
 
 
   const handleSave = async (data) => {
+    const { autoSave = false, ...payload } = data;
     if (!editorState.type) return;
     try {
       if (editorState.type === 'entry') {
@@ -100,7 +101,7 @@ export default function Notebook() {
           const res = await fetch(`/api/entries/${editorState.item.id}`, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ title: data.title, content: data.content }),
+            body: JSON.stringify({ title: payload.title, content: payload.content }),
           });
           if (!res.ok) throw new Error('Failed to update entry');
           const updated = await res.json();
@@ -125,8 +126,8 @@ export default function Notebook() {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
-              title: data.title,
-              content: data.content,
+              title: payload.title,
+              content: payload.content,
               subgroupId: editorState.parent.subgroupId,
             }),
           });
@@ -153,7 +154,7 @@ export default function Notebook() {
           const res = await fetch(`/api/subgroups/${editorState.item.id}`, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ name: data.name, description: data.description }),
+            body: JSON.stringify({ name: payload.name, description: payload.description }),
           });
           if (!res.ok) throw new Error('Failed to update subgroup');
           const updated = await res.json();
@@ -174,8 +175,8 @@ export default function Notebook() {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
-              name: data.name,
-              description: data.description,
+              name: payload.name,
+              description: payload.description,
               groupId: editorState.parent.groupId,
             }),
           });
@@ -196,7 +197,7 @@ export default function Notebook() {
           const res = await fetch(`/api/groups/${editorState.item.id}`, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ name: data.name, description: data.description }),
+            body: JSON.stringify({ name: payload.name, description: payload.description }),
           });
           if (!res.ok) throw new Error('Failed to update group');
           const updated = await res.json();
@@ -211,8 +212,8 @@ export default function Notebook() {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
-              name: data.name,
-              description: data.description,
+              name: payload.name,
+              description: payload.description,
               notebookId: notebook.id,
             }),
           });
@@ -229,7 +230,7 @@ export default function Notebook() {
           const res = await fetch(`/api/notebooks/${editorState.item.id}`, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ title: data.name, description: data.description }),
+            body: JSON.stringify({ title: payload.name, description: payload.description }),
           });
           if (!res.ok) throw new Error('Failed to update notebook');
           const updated = await res.json();
@@ -239,7 +240,7 @@ export default function Notebook() {
         const tagRes = await fetch('/api/tags', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ name: data.name, notebookId: notebook.id }),
+          body: JSON.stringify({ name: payload.name, notebookId: notebook.id }),
         });
         if (!tagRes.ok) throw new Error('Failed to create tag');
         const newTag = await tagRes.json();
@@ -272,15 +273,17 @@ export default function Notebook() {
     } catch (err) {
       console.error(err);
     } finally {
-      setEditorState({
-        isOpen: false,
-        type: null,
-        parent: null,
-        index: null,
-        item: null,
-        mode: 'create',
-        onDelete: null,
-      });
+      if (!autoSave) {
+        setEditorState({
+          isOpen: false,
+          type: null,
+          parent: null,
+          index: null,
+          item: null,
+          mode: 'create',
+          onDelete: null,
+        });
+      }
     }
   };
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -254,6 +254,7 @@ body {
   min-height: 0;
   width: 50%;
   margin-bottom: 1rem;
+  position: relative;
 }
 
 .editor-modal-content.fullscreen .editor-quill .ql-container {
@@ -287,6 +288,11 @@ body {
   height: 40px;
   transition: transform 0.2s ease-in-out, opacity 0.2s ease-in-out;
   transform: translateY(0);
+  position: absolute;
+  top: -2.5rem;
+  left: 0;
+  right: 0;
+  z-index: 50;
 }
 
 .editor-modal-content.fullscreen .toolbar-hidden .ql-toolbar {
@@ -312,7 +318,7 @@ body {
 
 .editor-header-wrapper {
   position: relative;
-  height: 4rem;
+  height: 2.5rem;
   /* allow Quill dropdowns to extend beyond the header wrapper */
   overflow: visible;
 }
@@ -393,6 +399,37 @@ body {
 .editor-modal-body textarea:focus {
   outline: none;
   box-shadow: none;
+}
+
+.entry-title-container {
+  position: sticky;
+  top: 0.5rem;
+  background: #fff;
+  z-index: 10;
+  padding-bottom: 0.5rem;
+}
+
+.entry-title-display {
+  font-size: 1rem;
+  cursor: pointer;
+  margin: 0;
+}
+
+.entry-title-input {
+  font-size: 1rem;
+  width: 100%;
+  border: none;
+  padding: 0;
+  margin-bottom: 0.25rem;
+}
+
+.entry-title-input:focus {
+  outline: none;
+}
+
+.last-saved {
+  font-size: 0.875rem;
+  color: #666;
 }
 
 .editor-modal-footer {


### PR DESCRIPTION
## Summary
- move entry title inline with content editor and style it like Notebook titles
- show last saved timestamp and autosave entries every 5 minutes
- keep editor open during autosave by updating Notebook save handler
- tweak toolbar positioning and header height

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_688bb8992d88832d9617466b87152280