### PR TITLE
Add entry archiving

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@
 - Groups: A group-by model than organizes related subgroups and is nested under Notebook
 - Subgroups: A group-by model that organizes related entries and is nested under Groups
 - Entries: The model that represents user-generated content
+- Entries may be archived instead of deleted. Archived entries are hidden by
+  default but can be shown using the "Show Archived" toggle in the notebook
+  controller. Archived items appear greyed out and can be restored later.
 - Tags: Meta data that relate to entries and are intended to be used to provide global search functionality
 
 ## Global Styles
@@ -117,5 +120,15 @@
 - tags
 - - [id].js
 - - index.js
+
+## Development
+
+After pulling changes that modify the Prisma schema, regenerate the client and
+apply migrations:
+
+```bash
+npx prisma generate
+npx prisma migrate deploy
+```
 
 

--- a/pages/api/entries/[id].js
+++ b/pages/api/entries/[id].js
@@ -34,7 +34,7 @@ export default async function handler(req, res) {
 
       case 'PUT':
         // Parse and validate input
-        const { title, content, subgroupId, tagIds } = req.body;
+        const { title, content, subgroupId, tagIds, archived } = req.body;
         if (title !== undefined && typeof title !== 'string') {
           return res.status(400).json({ error: 'Invalid title' });
         }
@@ -46,6 +46,9 @@ export default async function handler(req, res) {
         }
         if (tagIds !== undefined && (!Array.isArray(tagIds) || !tagIds.every(id => typeof id === 'string'))) {
           return res.status(400).json({ error: 'Invalid tagIds' });
+        }
+        if (archived !== undefined && typeof archived !== 'boolean') {
+          return res.status(400).json({ error: 'Invalid archived flag' });
         }
 
         // If subgroup change requested, verify new subgroup ownership
@@ -69,6 +72,7 @@ export default async function handler(req, res) {
             ...(tagIds !== undefined
               ? { tags: { set: tagIds.map(id => ({ id })) } }
               : {}),
+            ...(archived !== undefined ? { archived } : {}),
           },
           include: {
             tags: true,

--- a/pages/api/notebooks/[id]/tree.js
+++ b/pages/api/notebooks/[id]/tree.js
@@ -48,6 +48,12 @@ export default async function handler(req, res) {
 
     return res.status(200).json(notebook);
   } catch (error) {
+    if (error.message && error.message.includes('archived')) {
+      console.error('Migration required: missing archived column', error);
+      return res
+        .status(500)
+        .json({ error: 'Database schema out of date. Run migrations.' });
+    }
     console.error('GET /api/notebooks/[id]/tree error', error);
     return res.status(500).json({ error: 'Failed to fetch notebook tree' });
   }

--- a/prisma/migrations/20250719120000_add_archived_flag/migration.sql
+++ b/prisma/migrations/20250719120000_add_archived_flag/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "Entry" ADD COLUMN "archived" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -71,6 +71,7 @@ model Entry {
   subgroup     Subgroup   @relation(fields: [subgroupId], references: [id], onDelete: Cascade)
   subgroupId   String
   tags         Tag[]      @relation("EntryTags") // Metadata tags
+  archived     Boolean    @default(false)
   createdAt    DateTime   @default(now())
   updatedAt    DateTime   @updatedAt
 }

--- a/src/components/EntryEditor.jsx
+++ b/src/components/EntryEditor.jsx
@@ -16,6 +16,7 @@ export default function EntryEditor({
   onSave,
   onCancel,
   onDelete = null,
+  onArchive = null,
   initialData = {},
   mode = 'create',
 }) {
@@ -201,6 +202,11 @@ export default function EntryEditor({
               {mode === 'edit' && onDelete && (
                 <button className="editor-button danger" onClick={handleDelete}>
                   Delete
+                </button>
+              )}
+              {type === 'entry' && mode === 'edit' && onArchive && (
+                <button className="editor-button" onClick={onArchive}>
+                  {safeData.archived ? 'Restore' : 'Archive'}
                 </button>
               )}
               <button className="editor-button secondary" onClick={onCancel}>

--- a/src/components/Notebook.jsx
+++ b/src/components/Notebook.jsx
@@ -22,6 +22,7 @@ export default function Notebook() {
     item: null,
     mode: 'create',
     onDelete: null,
+    onArchive: null,
   });
   const [notebook, setNotebook] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -31,6 +32,7 @@ export default function Notebook() {
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [titleInput, setTitleInput] = useState('');
   const [showEdits, setShowEdits] = useState(false);
+  const [showArchived, setShowArchived] = useState(false);
 
   const groupRefs = useRef({});
   const subgroupRefs = useRef({});
@@ -282,6 +284,7 @@ export default function Notebook() {
           item: null,
           mode: 'create',
           onDelete: null,
+          onArchive: null,
         });
       }
     }
@@ -296,6 +299,7 @@ export default function Notebook() {
       item: null,
       mode: 'create',
       onDelete: null,
+      onArchive: null,
     });
   };
 
@@ -305,9 +309,10 @@ export default function Notebook() {
     index,
     item = null,
     mode = 'create',
-    onDelete = null
+    onDelete = null,
+    onArchive = null
   ) => {
-    setEditorState({ isOpen: true, type, parent, index, item, mode, onDelete });
+    setEditorState({ isOpen: true, type, parent, index, item, mode, onDelete, onArchive });
   };
 
   const toggleGroup = (group) => {
@@ -404,6 +409,36 @@ export default function Notebook() {
     }
   };
 
+  const handleToggleArchiveEntry = async (groupId, subgroupId, entryId, archived) => {
+    try {
+      const res = await fetch(`/api/entries/${entryId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ archived }),
+      });
+      if (!res.ok) throw new Error('Failed to update entry');
+      const updated = await res.json();
+      setNotebook((prev) => {
+        const groups = prev.groups.map((g) => {
+          if (g.id !== groupId) return g;
+          return {
+            ...g,
+            subgroups: g.subgroups.map((s) => {
+              if (s.id !== subgroupId) return s;
+              const entries = s.entries.map((e) =>
+                e.id === entryId ? { ...e, archived: updated.archived } : e
+              );
+              return { ...s, entries };
+            }),
+          };
+        });
+        return { ...prev, groups };
+      });
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
   const handleRemoveTag = async (groupId, subgroupId, entryId, tagId, tagIds) => {
     try {
       const newIds = tagIds.filter((id) => id !== tagId);
@@ -464,6 +499,8 @@ export default function Notebook() {
         onSelect={loadNotebook}
         showEdits={showEdits}
         onToggleEdits={setShowEdits}
+        showArchived={showArchived}
+        onToggleArchived={setShowArchived}
       />
       <h1 class="notebook-title"
         onClick={() => {
@@ -564,8 +601,13 @@ export default function Notebook() {
                         )}
                       </div>
                       <div className={`subgroup-children collapsible ${expandedSubgroups.includes(sub.id) ? 'open' : ''}`}> 
-                        {sub.entries.map((entry) => (
-                            <div key={entry.id} className={`entry-card ${expandedEntries.includes(entry.id) ? 'open' : ''}`}>
+                        {sub.entries
+                          .filter((e) => showArchived || !e.archived)
+                          .map((entry) => (
+                            <div
+                              key={entry.id}
+                              className={`entry-card ${expandedEntries.includes(entry.id) ? 'open' : ''} ${entry.archived ? 'archived' : ''}`}
+                            >
                               <div
                                 className="entry-header interactive"
                                 role="button"
@@ -649,10 +691,32 @@ export default function Notebook() {
                                           sub.id,
                                           entry.id
                                         )
+                                      ,
+                                      () =>
+                                        handleToggleArchiveEntry(
+                                          group.id,
+                                          sub.id,
+                                          entry.id,
+                                          !entry.archived
+                                        )
                                     );
                                   }}
                                 >
                                   Edit
+                                </button>
+                                <button
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    handleToggleArchiveEntry(
+                                      group.id,
+                                      sub.id,
+                                      entry.id,
+                                      !entry.archived
+                                    );
+                                  }}
+                                  style={{ marginLeft: '0.5rem' }}
+                                >
+                                  {entry.archived ? 'Restore' : 'Archive'}
                                 </button>
                               </div>
                             </div>
@@ -713,6 +777,7 @@ export default function Notebook() {
           onSave={handleSave}
           onCancel={handleCancel}
           onDelete={editorState.onDelete}
+          onArchive={editorState.onArchive}
           initialData={editorState.item}
           mode={editorState.mode}
         />

--- a/src/components/NotebookController.jsx
+++ b/src/components/NotebookController.jsx
@@ -6,7 +6,7 @@ import { EditOutlined, UserOutlined } from '@ant-design/icons';
 import { ThemeContext } from './ThemeProvider';
 
 
-export default function NotebookController({ onSelect, showEdits, onToggleEdits }) {
+export default function NotebookController({ onSelect, showEdits, onToggleEdits, showArchived, onToggleArchived }) {
   const [notebooks, setNotebooks] = useState([]);
   const [selected, setSelected] = useState('');
   const [showModal, setShowModal] = useState(false);
@@ -73,6 +73,12 @@ export default function NotebookController({ onSelect, showEdits, onToggleEdits 
           checked={showEdits}
           onChange={onToggleEdits}
           style={{ marginLeft: '0.5rem' }}
+        />
+        <span style={{ marginLeft: '0.5rem' }}>Show Archived</span>
+        <Switch
+          checked={showArchived}
+          onChange={onToggleArchived}
+          style={{ marginLeft: '0.25rem' }}
         />
       </div>
       <div className="profile-menu-container">

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -130,6 +130,10 @@ body {
   margin-left: 2rem;
   max-width: 90%;
 }
+.entry-card.archived {
+  background-color: #eee;
+  opacity: 0.6;
+}
 
 .entry-header {
   padding: 2rem;
@@ -598,6 +602,10 @@ body[data-theme='dark'] .add-subgroup,
 body[data-theme='dark'] .add-entry {
   background-color: #1f1f1f;
   color: #fff;
+}
+body[data-theme='dark'] .entry-card.archived {
+  background-color: #272727;
+  opacity: 0.6;
 }
 
 /* Form elements and links in dark mode */

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -135,6 +135,11 @@ body {
   opacity: 0.6;
 }
 
+.error-message {
+  color: red;
+  margin-left: 2rem;
+}
+
 .entry-header {
   padding: 2rem;
   border: 1px solid rgba(0, 0, 0, 0.3);
@@ -606,6 +611,9 @@ body[data-theme='dark'] .add-entry {
 body[data-theme='dark'] .entry-card.archived {
   background-color: #272727;
   opacity: 0.6;
+}
+body[data-theme='dark'] .error-message {
+  color: #ff8080;
 }
 
 /* Form elements and links in dark mode */


### PR DESCRIPTION
## Summary
- add `archived` flag to `Entry` model and migration
- handle `archived` in entry API
- show an archived toggle in NotebookController
- support archiving and restoring entries in Notebook
- show archive button in EntryEditor and entry cards
- style archived entries
- document archived entries in README
- update API tree route to surface missing-migration errors
- note migration step in README

## Testing
- `npx prisma generate`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688bc07e8758832dbb2f92e1d99cfa9a