### PR TITLE
Fix dark mode for editor modal

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -690,6 +690,29 @@ body[data-theme='dark'] .navbar {
   background-color: #1f1f1f;
   border-color: #333;
 }
+body[data-theme="dark"] .editor-modal-overlay.fullscreen {
+  background: rgba(0, 0, 0, 0.85);
+}
+
+body[data-theme="dark"] .editor-modal-content {
+  background-color: #1f1f1f;
+  color: #fff;
+}
+
+body[data-theme="dark"] .editor-modal-content.fullscreen .entry-title-container {
+  background: #1f1f1f;
+}
+
+body[data-theme="dark"] .editor-modal-content.fullscreen .ql-toolbar {
+  background-color: #333;
+  border: 1px solid #555;
+}
+
+body[data-theme="dark"] .editor-modal-content.fullscreen .ql-editor {
+  background-color: #1f1f1f;
+  color: #fff;
+}
+
 
 body[data-theme='light'] .navbar {
   background-color: #fff;


### PR DESCRIPTION
## Summary
- ensure fullscreen editor modal honors dark mode theme

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_688d2b74ba40832d8651632e74cc8d2f