### PR TITLE
Add user_sort and reorder persistence

### DIFF
--- a/pages/api/entries/index.js
+++ b/pages/api/entries/index.js
@@ -35,7 +35,7 @@ export default async function handler(req, res) {
             include: { group: true },
           },
         },
-        orderBy: { createdAt: 'desc' },
+        orderBy: { user_sort: 'asc' },
       });
       return res.status(200).json(entries);
     } catch (error) {
@@ -71,13 +71,17 @@ export default async function handler(req, res) {
         return res.status(404).json({ error: 'Subgroup not found' });
       }
 
-      // Create entry
+      const maxSort = await prisma.entry.aggregate({
+        where: { subgroupId },
+        _max: { user_sort: true },
+      });
       const newEntry = await prisma.entry.create({
         data: {
           title,
           content,
           userId,
           subgroupId,
+          user_sort: (maxSort._max.user_sort ?? -1) + 1,
           tags: tagIds
             ? { connect: tagIds.map(id => ({ id })) }
             : undefined,

--- a/pages/api/entries/reorder.js
+++ b/pages/api/entries/reorder.js
@@ -1,0 +1,39 @@
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../auth/[...nextauth]';
+import { prisma } from '../../../src/lib/prisma';
+
+export default async function handler(req, res) {
+  if (req.method !== 'PUT') {
+    res.setHeader('Allow', ['PUT']);
+    return res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) return res.status(401).json({ error: 'Unauthorized' });
+  const userId = session.user.id;
+
+  const { subgroupId, ids } = req.body;
+  if (!subgroupId || !Array.isArray(ids)) {
+    return res.status(400).json({ error: 'Invalid payload' });
+  }
+
+  try {
+    const subgroup = await prisma.subgroup.findUnique({
+      where: { id: subgroupId },
+      include: { group: { include: { notebook: true } } },
+    });
+    if (!subgroup || subgroup.group.notebook.userId !== userId) {
+      return res.status(404).json({ error: 'Subgroup not found' });
+    }
+
+    await prisma.$transaction(
+      ids.map((id, idx) =>
+        prisma.entry.update({ where: { id }, data: { user_sort: idx } })
+      )
+    );
+    return res.status(204).end();
+  } catch (error) {
+    console.error('PUT /api/entries/reorder error', error);
+    return res.status(500).json({ error: 'Failed to reorder entries' });
+  }
+}

--- a/pages/api/groups/index.js
+++ b/pages/api/groups/index.js
@@ -26,7 +26,7 @@ export default async function handler(req, res) {
             userId,
           },
         },
-        orderBy: { createdAt: 'desc' },
+        orderBy: { user_sort: 'asc' },
       });
       return res.status(200).json(groups);
     } catch (error) {
@@ -52,12 +52,16 @@ export default async function handler(req, res) {
       if (!notebook || notebook.userId !== userId) {
         return res.status(404).json({ error: 'Notebook not found' });
       }
-      // Create the group
+      const maxSort = await prisma.group.aggregate({
+        where: { notebookId },
+        _max: { user_sort: true },
+      });
       const newGroup = await prisma.group.create({
         data: {
           name,
           description: description?.trim() || null,
           notebookId,
+          user_sort: (maxSort._max.user_sort ?? -1) + 1,
         },
       });
       return res.status(201).json(newGroup);

--- a/pages/api/groups/reorder.js
+++ b/pages/api/groups/reorder.js
@@ -1,0 +1,36 @@
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../auth/[...nextauth]';
+import { prisma } from '../../../src/lib/prisma';
+
+export default async function handler(req, res) {
+  if (req.method !== 'PUT') {
+    res.setHeader('Allow', ['PUT']);
+    return res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) return res.status(401).json({ error: 'Unauthorized' });
+  const userId = session.user.id;
+
+  const { notebookId, ids } = req.body;
+  if (!notebookId || !Array.isArray(ids)) {
+    return res.status(400).json({ error: 'Invalid payload' });
+  }
+
+  try {
+    const notebook = await prisma.notebook.findUnique({ where: { id: notebookId } });
+    if (!notebook || notebook.userId !== userId) {
+      return res.status(404).json({ error: 'Notebook not found' });
+    }
+
+    await prisma.$transaction(
+      ids.map((id, idx) =>
+        prisma.group.update({ where: { id }, data: { user_sort: idx } })
+      )
+    );
+    return res.status(204).end();
+  } catch (error) {
+    console.error('PUT /api/groups/reorder error', error);
+    return res.status(500).json({ error: 'Failed to reorder groups' });
+  }
+}

--- a/pages/api/notebooks/[id]/tree.js
+++ b/pages/api/notebooks/[id]/tree.js
@@ -25,12 +25,14 @@ export default async function handler(req, res) {
       where: { id: notebookId },
       include: {
         groups: {
+          orderBy: { user_sort: 'asc' },
           include: {
             subgroups: {
+              orderBy: { user_sort: 'asc' },
               include: {
                 entries: {
                   include: { tags: true },
-                  orderBy: { createdAt: 'desc' }
+                  orderBy: { user_sort: 'asc' }
                 }
               }
             }

--- a/pages/api/subgroups/index.js
+++ b/pages/api/subgroups/index.js
@@ -27,7 +27,7 @@ export default async function handler(req, res) {
             },
           },
         },
-        orderBy: { createdAt: 'desc' },
+        orderBy: { user_sort: 'asc' },
       });
       return res.status(200).json(subgroups);
     } catch (error) {
@@ -53,12 +53,16 @@ export default async function handler(req, res) {
       if (!group || group.notebook.userId !== userId) {
         return res.status(404).json({ error: 'Group not found' });
       }
-      // Create the subgroup
+      const maxSort = await prisma.subgroup.aggregate({
+        where: { groupId },
+        _max: { user_sort: true },
+      });
       const newSubgroup = await prisma.subgroup.create({
         data: {
           name,
           description: description?.trim() || null,
           groupId,
+          user_sort: (maxSort._max.user_sort ?? -1) + 1,
         },
       });
       return res.status(201).json(newSubgroup);

--- a/pages/api/subgroups/reorder.js
+++ b/pages/api/subgroups/reorder.js
@@ -1,0 +1,39 @@
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../auth/[...nextauth]';
+import { prisma } from '../../../src/lib/prisma';
+
+export default async function handler(req, res) {
+  if (req.method !== 'PUT') {
+    res.setHeader('Allow', ['PUT']);
+    return res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) return res.status(401).json({ error: 'Unauthorized' });
+  const userId = session.user.id;
+
+  const { groupId, ids } = req.body;
+  if (!groupId || !Array.isArray(ids)) {
+    return res.status(400).json({ error: 'Invalid payload' });
+  }
+
+  try {
+    const group = await prisma.group.findUnique({
+      where: { id: groupId },
+      include: { notebook: true },
+    });
+    if (!group || group.notebook.userId !== userId) {
+      return res.status(404).json({ error: 'Group not found' });
+    }
+
+    await prisma.$transaction(
+      ids.map((id, idx) =>
+        prisma.subgroup.update({ where: { id }, data: { user_sort: idx } })
+      )
+    );
+    return res.status(204).end();
+  } catch (error) {
+    console.error('PUT /api/subgroups/reorder error', error);
+    return res.status(500).json({ error: 'Failed to reorder subgroups' });
+  }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -48,6 +48,7 @@ model Group {
   description  String?
   notebook     Notebook   @relation(fields: [notebookId], references: [id], onDelete: Cascade)
   notebookId   String
+  user_sort    Int        @default(0)
   subgroups    Subgroup[] // Group → Subgroups
   createdAt    DateTime   @default(now())
   updatedAt    DateTime   @updatedAt
@@ -59,6 +60,7 @@ model Subgroup {
   description  String?
   group        Group      @relation(fields: [groupId], references: [id], onDelete: Cascade)
   groupId      String
+  user_sort    Int        @default(0)
   entries      Entry[]    // Subgroup → Entries
   createdAt    DateTime   @default(now())
   updatedAt    DateTime   @updatedAt
@@ -72,6 +74,7 @@ model Entry {
   userId       String
   subgroup     Subgroup   @relation(fields: [subgroupId], references: [id], onDelete: Cascade)
   subgroupId   String
+  user_sort    Int        @default(0)
   tags         Tag[]      @relation("EntryTags") // Metadata tags
   archived     Boolean    @default(false)
   createdAt    DateTime   @default(now())

--- a/prisma/seed.mjs
+++ b/prisma/seed.mjs
@@ -63,11 +63,12 @@ async function main() {
     { name: 'Group 2' },
   ];
   const groups = [];
-  for (const info of groupData) {
+  for (const [idx, info] of groupData.entries()) {
     const group = await prisma.group.create({
       data: {
         name: info.name,
         notebookId: notebook.id,
+        user_sort: idx,
       },
     });
     groups.push(group);
@@ -80,13 +81,17 @@ async function main() {
     { name: 'Subgroup C', groupId: groups[1].id },
   ];
   const subgroups = [];
+  const subIndexMap = {};
   for (const info of subgroupData) {
+    const idx = subIndexMap[info.groupId] ?? 0;
     const subgroup = await prisma.subgroup.create({
       data: {
         name: info.name,
         groupId: info.groupId,
+        user_sort: idx,
       },
     });
+    subIndexMap[info.groupId] = idx + 1;
     subgroups.push(subgroup);
   }
 
@@ -111,18 +116,22 @@ async function main() {
       tagIds: [tags[2].id, tags[0].id],
     },
   ];
+  const entryIndexMap = {};
   for (const info of entryData) {
+    const idx = entryIndexMap[info.subgroupId] ?? 0;
     await prisma.entry.create({
       data: {
         title: info.title,
         content: info.content,
         userId: user.id,
         subgroupId: info.subgroupId,
+        user_sort: idx,
         tags: {
           connect: info.tagIds.map(id => ({ id })),
         },
       },
     });
+    entryIndexMap[info.subgroupId] = idx + 1;
   }
 
   console.log('🌱 Seed complete');

--- a/src/components/Notebook.jsx
+++ b/src/components/Notebook.jsx
@@ -348,8 +348,18 @@ export default function Notebook() {
       const oldIndex = prev.groups.findIndex((g) => g.id === active.id);
       const newIndex = prev.groups.findIndex((g) => g.id === over.id);
       const groups = arrayMove(prev.groups, oldIndex, newIndex);
+      // optimistic update
       return { ...prev, groups };
     });
+    const ids = notebook.groups.map((g) => g.id);
+    const oldIndex = ids.findIndex(id => id === active.id);
+    const newIndex = ids.findIndex(id => id === over.id);
+    const newIds = arrayMove(ids, oldIndex, newIndex);
+    fetch('/api/groups/reorder', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ notebookId: notebook.id, ids: newIds }),
+    }).catch((err) => console.error(err));
   };
 
   const handleSubgroupDragEnd = (groupId) => ({ active, over }) => {
@@ -364,6 +374,18 @@ export default function Notebook() {
       });
       return { ...prev, groups };
     });
+    const target = notebook.groups.find((g) => g.id === groupId);
+    if (target) {
+      const ids = target.subgroups.map((s) => s.id);
+      const oldIdx = ids.findIndex((id) => id === active.id);
+      const newIdx = ids.findIndex((id) => id === over.id);
+      const newIds = arrayMove(ids, oldIdx, newIdx);
+      fetch('/api/subgroups/reorder', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ groupId, ids: newIds }),
+      }).catch((err) => console.error(err));
+    }
   };
 
   const handleEntryDragEnd = (groupId, subgroupId) => ({ active, over }) => {
@@ -384,6 +406,19 @@ export default function Notebook() {
       });
       return { ...prev, groups };
     });
+    const group = notebook.groups.find((g) => g.id === groupId);
+    const sub = group?.subgroups.find((s) => s.id === subgroupId);
+    if (sub) {
+      const ids = sub.entries.map((e) => e.id);
+      const oldIdx = ids.findIndex((id) => id === active.id);
+      const newIdx = ids.findIndex((id) => id === over.id);
+      const newIds = arrayMove(ids, oldIdx, newIdx);
+      fetch('/api/entries/reorder', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ subgroupId, ids: newIds }),
+      }).catch((err) => console.error(err));
+    }
   };
 
   const toggleGroup = (group) => {


### PR DESCRIPTION
## Summary
- add `user_sort` column to Group, Subgroup and Entry models
- handle ordering in groups, subgroups and entries APIs
- expose new reorder endpoints for groups, subgroups and entries
- sort the notebook tree by `user_sort`
- update drag-and-drop handlers to persist ordering
- seed data with initial sort indexes

## Testing
- `npm run build`
- `npx prisma generate`


------
https://chatgpt.com/codex/tasks/task_b_688d6384fdb8832d92556e55490489eb