### PR TITLE
feat: add account management page

### DIFF
--- a/pages/account.js
+++ b/pages/account.js
@@ -1,4 +1,4 @@
-import Account from '../components/Account';
+import Account from '../src/components/Account';
 
 export default function AccountPage() {
   return <Account />;

--- a/pages/api/account/index.js
+++ b/pages/api/account/index.js
@@ -1,0 +1,73 @@
+// pages/api/account/index.js
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../auth/[...nextauth]';
+import { PrismaClient } from '@prisma/client';
+import bcrypt from 'bcryptjs';
+
+const prisma = new PrismaClient();
+
+export default async function handler(req, res) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) return res.status(401).json({ error: 'Unauthorized' });
+
+  const userId = session.user.id;
+
+  switch (req.method) {
+    case 'GET': {
+      try {
+        const user = await prisma.user.findUnique({
+          where: { id: userId },
+          select: { username: true, email: true, createdAt: true },
+        });
+        const [notebooks, groups, subgroups, entries, tags] = await Promise.all([
+          prisma.notebook.count({ where: { userId } }),
+          prisma.group.count({ where: { notebook: { userId } } }),
+          prisma.subgroup.count({ where: { group: { notebook: { userId } } } }),
+          prisma.entry.count({ where: { userId } }),
+          prisma.tag.count({ where: { notebook: { userId } } }),
+        ]);
+        return res.status(200).json({
+          username: user.username,
+          email: user.email,
+          createdAt: user.createdAt,
+          stats: { notebooks, groups, subgroups, entries, tags },
+        });
+      } catch (error) {
+        console.error('GET /api/account error', error);
+        return res.status(500).json({ error: 'Failed to load account' });
+      }
+    }
+    case 'PUT': {
+      try {
+        const { username, email, password } = req.body;
+        const data = {};
+        if (username !== undefined) data.username = username;
+        if (email !== undefined) data.email = email;
+        if (password) data.passwordHash = await bcrypt.hash(password, 10);
+        const updated = await prisma.user.update({
+          where: { id: userId },
+          data,
+        });
+        return res
+          .status(200)
+          .json({ username: updated.username, email: updated.email });
+      } catch (error) {
+        console.error('PUT /api/account error', error);
+        return res.status(500).json({ error: 'Failed to update account' });
+      }
+    }
+    case 'DELETE': {
+      try {
+        await prisma.user.delete({ where: { id: userId } });
+        return res.status(204).end();
+      } catch (error) {
+        console.error('DELETE /api/account error', error);
+        return res.status(500).json({ error: 'Failed to delete account' });
+      }
+    }
+    default: {
+      res.setHeader('Allow', ['GET', 'PUT', 'DELETE']);
+      return res.status(405).end(`Method ${req.method} Not Allowed`);
+    }
+  }
+}

--- a/src/components/Account.jsx
+++ b/src/components/Account.jsx
@@ -1,28 +1,100 @@
-import React, { useState } from 'react';
-import { Avatar, Switch, Input, Button } from 'antd';
-import { UserOutlined } from '@ant-design/icons';
+import React, { useState, useEffect } from 'react';
+import { Avatar, Switch, Input, Button, Modal, message } from 'antd';
+import { UserOutlined, ExclamationCircleOutlined } from '@ant-design/icons';
+import { signOut } from 'next-auth/react';
 
 export default function Account() {
   const [isEditing, setIsEditing] = useState(false);
-  const [username, setUsername] = useState('User Name');
-  const [email, setEmail] = useState('user@example.com');
+  const [username, setUsername] = useState('');
+  const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-
-  const stats = {
-    createdAt: 'January 1, 2024',
+  const [loading, setLoading] = useState(false);
+  const [stats, setStats] = useState({
+    createdAt: '',
     notebooks: 0,
     groups: 0,
     subgroups: 0,
     entries: 0,
     tags: 0,
+  });
+
+  useEffect(() => {
+    async function fetchAccount() {
+      try {
+        const res = await fetch('/api/account');
+        if (!res.ok) throw new Error('Failed to load account');
+        const data = await res.json();
+        setUsername(data.username);
+        setEmail(data.email);
+        setStats({
+          createdAt: data.createdAt,
+          notebooks: data.stats.notebooks,
+          groups: data.stats.groups,
+          subgroups: data.stats.subgroups,
+          entries: data.stats.entries,
+          tags: data.stats.tags,
+        });
+      } catch (err) {
+        console.error(err);
+      }
+    }
+    fetchAccount();
+  }, []);
+
+  const handleSave = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch('/api/account', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, email, password: password || undefined }),
+      });
+      if (!res.ok) throw new Error('Failed to update account');
+      const data = await res.json();
+      setUsername(data.username);
+      setEmail(data.email);
+      setPassword('');
+      setIsEditing(false);
+      message.success('Account updated');
+    } catch (err) {
+      console.error(err);
+      message.error('Failed to update account');
+    } finally {
+      setLoading(false);
+    }
   };
+
+  const handleDelete = () => {
+    Modal.confirm({
+      title: 'Delete account?',
+      icon: <ExclamationCircleOutlined />,
+      content: 'This action is irreversible and all of your data will be lost.',
+      okText: 'Delete',
+      okType: 'danger',
+      cancelText: 'Cancel',
+      async onOk() {
+        try {
+          const res = await fetch('/api/account', { method: 'DELETE' });
+          if (!res.ok) throw new Error('Failed to delete account');
+          await signOut({ callbackUrl: '/' });
+        } catch (err) {
+          console.error(err);
+          message.error('Failed to delete account');
+        }
+      },
+    });
+  };
+
+  const formattedDate = stats.createdAt
+    ? new Date(stats.createdAt).toLocaleDateString()
+    : '';
 
   return (
     <div style={{ maxWidth: 400, margin: '0 auto' }}>
       <div style={{ textAlign: 'center', marginBottom: '1rem' }}>
         <Avatar size={64} icon={<UserOutlined />} />
         <h2 style={{ marginTop: '0.5rem' }}>{username}</h2>
-        <p>Joined on {stats.createdAt}</p>
+        {formattedDate && <p>Joined on {formattedDate}</p>}
       </div>
 
       <div style={{ marginBottom: '1rem' }}>
@@ -33,7 +105,14 @@ export default function Account() {
         <p>Tags: {stats.tags}</p>
       </div>
 
-      <div style={{ display: 'flex', alignItems: 'center', marginBottom: '1rem', gap: '0.5rem' }}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          marginBottom: '1rem',
+          gap: '0.5rem',
+        }}
+      >
         <span>Enable Editing</span>
         <Switch checked={isEditing} onChange={setIsEditing} />
       </div>
@@ -59,7 +138,16 @@ export default function Account() {
         disabled={!isEditing}
         style={{ marginBottom: '0.5rem' }}
       />
-      <Button danger disabled={!isEditing} style={{ width: '100%' }}>
+      <Button
+        type="primary"
+        disabled={!isEditing}
+        onClick={handleSave}
+        loading={loading}
+        style={{ marginBottom: '0.5rem', width: '100%' }}
+      >
+        Save Changes
+      </Button>
+      <Button danger disabled={!isEditing} onClick={handleDelete} style={{ width: '100%' }}>
         Delete Account
       </Button>
     </div>

--- a/src/components/Account.jsx
+++ b/src/components/Account.jsx
@@ -1,0 +1,67 @@
+import React, { useState } from 'react';
+import { Avatar, Switch, Input, Button } from 'antd';
+import { UserOutlined } from '@ant-design/icons';
+
+export default function Account() {
+  const [isEditing, setIsEditing] = useState(false);
+  const [username, setUsername] = useState('User Name');
+  const [email, setEmail] = useState('user@example.com');
+  const [password, setPassword] = useState('');
+
+  const stats = {
+    createdAt: 'January 1, 2024',
+    notebooks: 0,
+    groups: 0,
+    subgroups: 0,
+    entries: 0,
+    tags: 0,
+  };
+
+  return (
+    <div style={{ maxWidth: 400, margin: '0 auto' }}>
+      <div style={{ textAlign: 'center', marginBottom: '1rem' }}>
+        <Avatar size={64} icon={<UserOutlined />} />
+        <h2 style={{ marginTop: '0.5rem' }}>{username}</h2>
+        <p>Joined on {stats.createdAt}</p>
+      </div>
+
+      <div style={{ marginBottom: '1rem' }}>
+        <p>Notebooks: {stats.notebooks}</p>
+        <p>Groups: {stats.groups}</p>
+        <p>Subgroups: {stats.subgroups}</p>
+        <p>Entries: {stats.entries}</p>
+        <p>Tags: {stats.tags}</p>
+      </div>
+
+      <div style={{ display: 'flex', alignItems: 'center', marginBottom: '1rem', gap: '0.5rem' }}>
+        <span>Enable Editing</span>
+        <Switch checked={isEditing} onChange={setIsEditing} />
+      </div>
+
+      <Input
+        value={username}
+        onChange={(e) => setUsername(e.target.value)}
+        placeholder="Username"
+        disabled={!isEditing}
+        style={{ marginBottom: '0.5rem' }}
+      />
+      <Input
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="Email"
+        disabled={!isEditing}
+        style={{ marginBottom: '0.5rem' }}
+      />
+      <Input.Password
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        placeholder="Password"
+        disabled={!isEditing}
+        style={{ marginBottom: '0.5rem' }}
+      />
+      <Button danger disabled={!isEditing} style={{ width: '100%' }}>
+        Delete Account
+      </Button>
+    </div>
+  );
+}

--- a/src/components/NotebookController.jsx
+++ b/src/components/NotebookController.jsx
@@ -86,6 +86,9 @@ export default function NotebookController({ onSelect, showEdits, onToggleEdits,
 
 
         <div className="profile-menu">
+          <a href="/account" style={{ display: 'block', marginBottom: '0.5rem' }}>
+            Account
+          </a>
           <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.5rem' }}>
             <span>Dark Mode</span>
             <Switch checked={darkMode} onChange={toggleTheme} />

--- a/src/components/NotebookController.jsx
+++ b/src/components/NotebookController.jsx
@@ -4,6 +4,7 @@ import { Switch, Avatar } from 'antd';
 import EntryEditor from './EntryEditor';
 import { EditOutlined, UserOutlined } from '@ant-design/icons';
 import { ThemeContext } from './ThemeProvider';
+import Link from 'next/link';
 
 
 export default function NotebookController({ onSelect, showEdits, onToggleEdits, showArchived, onToggleArchived }) {
@@ -86,9 +87,9 @@ export default function NotebookController({ onSelect, showEdits, onToggleEdits,
 
 
         <div className="profile-menu">
-          <a href="/account" style={{ display: 'block', marginBottom: '0.5rem' }}>
+          <Link href="/account" style={{ display: 'block', marginBottom: '0.5rem' }}>
             Account
-          </a>
+          </Link>
           <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.5rem' }}>
             <span>Dark Mode</span>
             <Switch checked={darkMode} onChange={toggleTheme} />

--- a/src/pages/account.js
+++ b/src/pages/account.js
@@ -1,0 +1,5 @@
+import Account from '../components/Account';
+
+export default function AccountPage() {
+  return <Account />;
+}


### PR DESCRIPTION
## Summary
- scaffold account management page with editing toggle and profile info
- add link to account page in avatar menu

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_688d8baada4c832d8a484c4b0bef621e