### PR TITLE
Show entry timestamps in collapsed cards

### DIFF
--- a/src/components/Notebook.jsx
+++ b/src/components/Notebook.jsx
@@ -867,7 +867,12 @@ export default function Notebook() {
                                                                       <p key={idx}>{para}</p>
                                                                     ))
                                                                 : (
-                                                                  <div>{htmlToText(entry.content).slice(0, 40)}...</div>
+                                                                  <div>
+                                                                    <div>{htmlToText(entry.content).slice(0, 40)}...</div>
+                                                                    <div className="entry-card-timestamps">
+                                                                      Last Updated: {new Date(entry.updatedAt).toLocaleString()} | Created At: {new Date(entry.createdAt).toLocaleString()}
+                                                                    </div>
+                                                                  </div>
                                                                 )}
                                                             </div>
                                                           </div>


### PR DESCRIPTION
## Summary
- display creation and last update timestamps on collapsed entry cards

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688da8c8ac38832d9bf39ca1a2aa3697