### PR TITLE
feat: allow custom notebook terminology

### DIFF
--- a/pages/api/notebooks/[id].js
+++ b/pages/api/notebooks/[id].js
@@ -28,7 +28,7 @@ export default async function handler(req, res) {
     case 'PUT':
       // Update notebook
       try {
-        const { title, description } = req.body;
+        const { title, description, user_notebook_tree } = req.body;
         if (title && typeof title !== 'string') {
           return res.status(400).json({ error: 'Invalid title' });
         }
@@ -37,6 +37,7 @@ export default async function handler(req, res) {
           data: {
             ...(title !== undefined ? { title } : {}),
             ...(description !== undefined ? { description } : {}),
+            ...(user_notebook_tree !== undefined ? { user_notebook_tree } : {}),
           },
         });
         return res.status(200).json(updated);

--- a/pages/api/notebooks/index.js
+++ b/pages/api/notebooks/index.js
@@ -19,10 +19,10 @@ export default async function handler(req, res) {
   }
 
   if (req.method === "POST") {
-    const { title, description } = req.body;
+    const { title, description, user_notebook_tree } = req.body;
     if (!title) return res.status(400).json({ error: "Missing title" });
     const newNb = await prisma.notebook.create({
-      data: { title, description, userId },
+      data: { title, description, userId, user_notebook_tree },
     });
     return res.status(201).json(newNb);
   }

--- a/prisma/migrations/20250724120000_add_user_notebook_tree/migration.sql
+++ b/prisma/migrations/20250724120000_add_user_notebook_tree/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "Notebook" ADD COLUMN "user_notebook_tree" TEXT[] DEFAULT ARRAY['Group','Subgroup','Entry'];

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,6 +36,7 @@ model Notebook {
   userId       String
   groups       Group[]   // Notebook → Groups
   tags         Tag[]     // Metadata tags scoped to this notebook
+  user_notebook_tree String[] @default(["Group", "Subgroup", "Entry"])
   createdAt    DateTime  @default(now())
   updatedAt    DateTime  @updatedAt
 }

--- a/src/components/EntryEditor.jsx
+++ b/src/components/EntryEditor.jsx
@@ -19,6 +19,7 @@ export default function EntryEditor({
   onArchive = null,
   initialData = {},
   mode = 'create',
+  aliases = { group: 'Group', subgroup: 'Subgroup', entry: 'Entry' },
 }) {
   // `initialData` may explicitly be passed as `null` when creating a new item.
   // Normalize it to an empty object so property accesses do not fail.
@@ -28,6 +29,15 @@ export default function EntryEditor({
   const [content, setContent] = useState(safeData.content || '');
   const [name, setName] = useState(safeData.name || ''); // for groups, subgroups, tags
   const [description, setDescription] = useState(safeData.description || '');
+  const [groupAlias, setGroupAlias] = useState(
+    (safeData.user_notebook_tree && safeData.user_notebook_tree[0]) || ''
+  );
+  const [subgroupAlias, setSubgroupAlias] = useState(
+    (safeData.user_notebook_tree && safeData.user_notebook_tree[1]) || ''
+  );
+  const [entryAlias, setEntryAlias] = useState(
+    (safeData.user_notebook_tree && safeData.user_notebook_tree[2]) || ''
+  );
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [titleInput, setTitleInput] = useState('');
   const [lastSaved, setLastSaved] = useState(null);
@@ -53,6 +63,9 @@ export default function EntryEditor({
     setName(data.name || '');
     setDescription(data.description || '');
     setTitleInput(data.title || '');
+    setGroupAlias((data.user_notebook_tree && data.user_notebook_tree[0]) || '');
+    setSubgroupAlias((data.user_notebook_tree && data.user_notebook_tree[1]) || '');
+    setEntryAlias((data.user_notebook_tree && data.user_notebook_tree[2]) || '');
   }, [initialData]);
 
   const handleSave = () => {
@@ -76,13 +89,21 @@ export default function EntryEditor({
       alert('Name cannot be empty.');
       return;
     }
-    onSave({
+    const payload = {
       name: name.trim(),
       description: description.trim(),
       parent,
       mode,
       id: safeData.id,
-    });
+    };
+    if (type === 'notebook') {
+      payload.user_notebook_tree = [
+        (groupAlias || 'Group').trim(),
+        (subgroupAlias || 'Subgroup').trim(),
+        (entryAlias || 'Entry').trim(),
+      ];
+    }
+    onSave(payload);
     setLastSaved(new Date());
   };
 
@@ -187,10 +208,18 @@ export default function EntryEditor({
         >
           <div className={`editor-modal-header ${headerVisible ? '' : 'hidden'}`}>
             <h2 className="editor-modal-title">
-              {type === 'entry' && (mode === 'edit' ? 'Edit Entry' : 'New Entry')}
-              {type === 'group' && (mode === 'edit' ? 'Edit Group' : 'New Group')}
+              {type === 'entry' &&
+                (mode === 'edit'
+                  ? `Edit ${aliases.entry}`
+                  : `New ${aliases.entry}`)}
+              {type === 'group' &&
+                (mode === 'edit'
+                  ? `Edit ${aliases.group}`
+                  : `New ${aliases.group}`)}
               {type === 'subgroup' &&
-                (mode === 'edit' ? 'Edit Subgroup' : 'New Subgroup')}
+                (mode === 'edit'
+                  ? `Edit ${aliases.subgroup}`
+                  : `New ${aliases.subgroup}`)}
               {type === 'notebook' &&
                 (mode === 'edit' ? 'Edit Notebook' : 'New Notebook')}
               {type === 'tag' && (mode === 'edit' ? 'Edit Tag' : 'New Tag')}
@@ -286,6 +315,31 @@ export default function EntryEditor({
                   value={description}
                   onChange={(e) => setDescription(e.target.value)}
                 />
+              )}
+              {type === 'notebook' && (
+                <>
+                  <input
+                    className="editor-input-title"
+                    type="text"
+                    placeholder="Group alias"
+                    value={groupAlias}
+                    onChange={(e) => setGroupAlias(e.target.value)}
+                  />
+                  <input
+                    className="editor-input-title"
+                    type="text"
+                    placeholder="Subgroup alias"
+                    value={subgroupAlias}
+                    onChange={(e) => setSubgroupAlias(e.target.value)}
+                  />
+                  <input
+                    className="editor-input-title"
+                    type="text"
+                    placeholder="Entry alias"
+                    value={entryAlias}
+                    onChange={(e) => setEntryAlias(e.target.value)}
+                  />
+                </>
               )}
             </>
           )}

--- a/src/components/Notebook.jsx
+++ b/src/components/Notebook.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useMemo } from 'react';
 
 
 import EntryEditor from './EntryEditor';
@@ -48,6 +48,15 @@ export default function Notebook() {
   const [showEdits, setShowEdits] = useState(false);
   const [showArchived, setShowArchived] = useState(false);
   const [loadError, setLoadError] = useState('');
+
+  const aliases = useMemo(
+    () => ({
+      group: notebook?.user_notebook_tree?.[0] || 'Group',
+      subgroup: notebook?.user_notebook_tree?.[1] || 'Subgroup',
+      entry: notebook?.user_notebook_tree?.[2] || 'Entry',
+    }),
+    [notebook]
+  );
 
   const sensors = useSensors(useSensor(PointerSensor));
 
@@ -915,7 +924,7 @@ export default function Notebook() {
                                                                   subgroupId: sub.id,
                                                                   groupId: group.id,
                                                                   tagIds: entry.tags.map((t) => t.id),
-                                                                  label: `Entry: ${entry.title}`,
+                                                                  label: `${aliases.entry}: ${entry.title}`,
                                                                 },
                                                                 entry.tags.length - 1
                                                               );
@@ -980,13 +989,13 @@ export default function Notebook() {
                                                     {
                                                       subgroupId: sub.id,
                                                       groupId: group.id,
-                                                      label: `Subgroup: ${sub.name}`,
+                                                      label: `${aliases.subgroup}: ${sub.name}`,
                                                     },
                                                     sub.entries.length - 1
                                                   );
                                                 }}
                                               >
-                                                Add Entry
+                                                Add {aliases.entry}
                                               </div>
                                             </SortableContext>
                                           </DndContext>
@@ -1004,12 +1013,12 @@ export default function Notebook() {
                                   e.stopPropagation();
                                   openEditor(
                                     'subgroup',
-                                    { groupId: group.id, label: `Group: ${group.name}` },
+                                    { groupId: group.id, label: `${aliases.group}: ${group.name}` },
                                     group.subgroups.length - 1
                                   );
                                 }}
                               >
-                                Add Subgroup
+                                Add {aliases.subgroup}
                               </div>
                             </SortableContext>
                           </DndContext>
@@ -1024,10 +1033,14 @@ export default function Notebook() {
                 role="button"
                 tabIndex={0}
                 onClick={() =>
-                  openEditor('group', { label: 'Notebook Root' }, notebook.groups.length - 1)
+                  openEditor(
+                    'group',
+                    { label: `${aliases.group} Root` },
+                    notebook.groups.length - 1
+                  )
                 }
               >
-                Add Group
+                Add {aliases.group}
               </div>
             </SortableContext>
           </DndContext>
@@ -1044,6 +1057,7 @@ export default function Notebook() {
           onArchive={editorState.onArchive}
           initialData={editorState.item}
           mode={editorState.mode}
+          aliases={aliases}
         />
       )}
     </div>

--- a/src/components/NotebookController.jsx
+++ b/src/components/NotebookController.jsx
@@ -37,12 +37,12 @@ export default function NotebookController({ onSelect, showEdits, onToggleEdits,
     onSelect(id);
   };
 
-  const handleCreate = async ({ name, description }) => {
+  const handleCreate = async ({ name, description, user_notebook_tree }) => {
     try {
       const res = await fetch('/api/notebooks', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ title: name, description }),
+        body: JSON.stringify({ title: name, description, user_notebook_tree }),
       });
       if (!res.ok) throw new Error('Failed to create notebook');
       const newNb = await res.json();


### PR DESCRIPTION
## Summary
- allow notebooks to specify custom aliases for group, subgroup, and entry levels
- surface mapped terminology throughout the notebook UI
- expose user_notebook_tree on notebook API endpoints

## Testing
- `npx prisma generate`
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688db0d85004832dbb5e4212373e4363