### PR TITLE
Fix notebook modal input resets and layout overflow

### DIFF
--- a/src/components/EntryEditor.jsx
+++ b/src/components/EntryEditor.jsx
@@ -66,7 +66,7 @@ export default function EntryEditor({
     setGroupAlias((data.user_notebook_tree && data.user_notebook_tree[0]) || '');
     setSubgroupAlias((data.user_notebook_tree && data.user_notebook_tree[1]) || '');
     setEntryAlias((data.user_notebook_tree && data.user_notebook_tree[2]) || '');
-  }, [initialData]);
+  }, [initialData?.id]);
 
   const handleSave = () => {
     if (type === 'entry') {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -323,7 +323,8 @@ body {
   border-radius: 1em;
   width: 50vw;
   max-width: 65vw;
-  height: 30%;
+  max-height: 80vh;
+  overflow-y: auto;
 }
 
 .editor-modal-header {


### PR DESCRIPTION
## Summary
- prevent entry editor's create notebook fields from resetting while typing
- allow notebook creation modal to grow and scroll

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_688e1b330bd4832d9c10c31c3a43b970