### PR TITLE
feat: add precursor model and seed data

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@
   default but can be shown using the "Show Archived" toggle in the notebook
   controller. Archived items appear greyed out and can be restored later.
 - Tags: Meta data that relate to entries and are intended to be used to provide global search functionality
+- Pattern: The set of notebook aliases (Title, Description, Groups, Subgroups, Entries) that define the structure of a notebook
+- Model: A notebook instance with at least one group and one subgroup, representing data shaped by a pattern
+- Precursor: A pre-patterned and pre-modeled notebook template, defined by an `id`, a `pattern`, and `modelData`
 
 ## Global Styles
 - font-family: "IBM Plex Mono", "Cutive Mono", monospace;

--- a/prisma/migrations/20250802162000_add_precursors_model/migration.sql
+++ b/prisma/migrations/20250802162000_add_precursors_model/migration.sql
@@ -1,0 +1,19 @@
+-- AlterTable
+ALTER TABLE "public"."Notebook" ADD COLUMN     "precursorId" TEXT;
+
+-- CreateTable
+CREATE TABLE "public"."Precursor" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "pattern" JSONB NOT NULL,
+    "modelData" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Precursor_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "public"."Notebook" ADD CONSTRAINT "Notebook_precursorId_fkey" FOREIGN KEY ("precursorId") REFERENCES "public"."Precursor"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,6 +37,19 @@ model Notebook {
   groups       Group[]   // Notebook → Groups
   tags         Tag[]     // Metadata tags scoped to this notebook
   user_notebook_tree String[] @default(["Group", "Subgroup", "Entry"])
+  precursor     Precursor? @relation(fields: [precursorId], references: [id])
+  precursorId   String?
+  createdAt    DateTime  @default(now())
+  updatedAt    DateTime  @updatedAt
+}
+
+model Precursor {
+  id           String    @id @default(uuid())
+  title        String
+  description  String?
+  pattern      Json
+  modelData    Json
+  notebooks    Notebook[]
   createdAt    DateTime  @default(now())
   updatedAt    DateTime  @updatedAt
 }

--- a/prisma/seed.mjs
+++ b/prisma/seed.mjs
@@ -1,4 +1,8 @@
 import { PrismaClient } from '@prisma/client';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
 const prisma = new PrismaClient();
 
 async function main() {
@@ -25,7 +29,28 @@ async function main() {
     },
   });
 
-  // 3. Upsert demo notebook
+  // 3. Seed a precursor with pattern and model data
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const criteriaPath = path.join(__dirname, 'data', 'criteria.json');
+  const criteriaData = JSON.parse(readFileSync(criteriaPath, 'utf-8'));
+
+  await prisma.precursor.upsert({
+    where: { id: '11111111-1111-1111-1111-111111111111' },
+    update: {},
+    create: {
+      id: '11111111-1111-1111-1111-111111111111',
+      title: 'Autism Diagnostic Criteria',
+      description: 'DSM-5 autism spectrum disorder diagnostic criteria',
+      pattern: {
+        group: 'Diagnostic Criteria',
+        subgroup: 'Subcriteria',
+        entry: 'Observation',
+      },
+      modelData: criteriaData,
+    },
+  });
+
+  // 4. Upsert demo notebook
   const notebook = await prisma.notebook.upsert({
     where: { id: '00000000-0000-0000-0000-000000000000' },
     update: {},
@@ -37,7 +62,7 @@ async function main() {
     },
   });
 
-  // 4. Create metadata tags for this notebook
+  // 5. Create metadata tags for this notebook
   const tagData = [
     { code: 'important', name: 'Important' },
     { code: 'todo', name: 'To Do' },
@@ -57,7 +82,7 @@ async function main() {
     tags.push(tag);
   }
 
-  // 5. Create groups inside the notebook
+  // 6. Create groups inside the notebook
   const groupData = [
     { name: 'Group 1' },
     { name: 'Group 2' },
@@ -73,7 +98,7 @@ async function main() {
     groups.push(group);
   }
 
-  // 6. Create subgroups under each group
+  // 7. Create subgroups under each group
   const subgroupData = [
     { name: 'Subgroup A', groupId: groups[0].id },
     { name: 'Subgroup B', groupId: groups[0].id },
@@ -90,7 +115,7 @@ async function main() {
     subgroups.push(subgroup);
   }
 
-  // 7. Create entries in each subgroup, attaching some tags
+  // 8. Create entries in each subgroup, attaching some tags
   const entryData = [
     {
       title: 'Entry 1A',


### PR DESCRIPTION
## Summary
- document patterns, models, and precursors
- add `Precursor` prisma model and relation to `Notebook`
- seed database with an autism diagnostic criteria precursor

## Testing
- `npx prisma generate`
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688e3a553d3c832dac49a4ef03e2836f