### PR TITLE
Add precursor API endpoints and notebook cloning

### DIFF
--- a/pages/api/notebooks/index.js
+++ b/pages/api/notebooks/index.js
@@ -19,10 +19,83 @@ export default async function handler(req, res) {
   }
 
   if (req.method === "POST") {
-    const { title, description, user_notebook_tree } = req.body;
+    const { title, description, user_notebook_tree, precursorId } = req.body || {};
     if (!title) return res.status(400).json({ error: "Missing title" });
+
+    if (precursorId) {
+      try {
+        const precursor = await prisma.precursor.findUnique({ where: { id: precursorId } });
+        if (!precursor) {
+          return res.status(404).json({ error: "Precursor not found" });
+        }
+
+        const tree = [
+          precursor.pattern?.group || "Group",
+          precursor.pattern?.subgroup || "Subgroup",
+          precursor.pattern?.entry || "Entry",
+        ];
+
+        const newNb = await prisma.$transaction(async (tx) => {
+          const nb = await tx.notebook.create({
+            data: {
+              title,
+              description,
+              userId,
+              user_notebook_tree: tree,
+              precursorId,
+            },
+          });
+
+          for (const g of precursor.modelData || []) {
+            const group = await tx.group.create({
+              data: {
+                name: g.title || g.id || "Group",
+                notebookId: nb.id,
+              },
+            });
+            if (Array.isArray(g.subcriteria)) {
+              for (const sg of g.subcriteria) {
+                const subgroup = await tx.subgroup.create({
+                  data: {
+                    name: sg.title || sg.id || "Subgroup",
+                    groupId: group.id,
+                  },
+                });
+                if (Array.isArray(sg.entries)) {
+                  for (const e of sg.entries) {
+                    await tx.entry.create({
+                      data: {
+                        title: e.title || e.id || "Entry",
+                        content: e.content || "",
+                        userId,
+                        subgroupId: subgroup.id,
+                      },
+                    });
+                  }
+                }
+              }
+            }
+          }
+
+          return nb;
+        });
+
+        return res.status(201).json(newNb);
+      } catch (error) {
+        console.error("POST /api/notebooks error", error);
+        return res
+          .status(500)
+          .json({ error: "Failed to create notebook from precursor" });
+      }
+    }
+
     const newNb = await prisma.notebook.create({
-      data: { title, description, userId, user_notebook_tree },
+      data: {
+        title,
+        description,
+        userId,
+        ...(user_notebook_tree ? { user_notebook_tree } : {}),
+      },
     });
     return res.status(201).json(newNb);
   }

--- a/pages/api/precursors/[id].js
+++ b/pages/api/precursors/[id].js
@@ -1,0 +1,55 @@
+import { PrismaClient } from '@prisma/client';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../auth/[...nextauth]';
+
+const prisma = new PrismaClient();
+
+export default async function handler(req, res) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) return res.status(401).json({ error: 'Unauthorized' });
+
+  const { id } = req.query;
+
+  switch (req.method) {
+    case 'GET': {
+      try {
+        const precursor = await prisma.precursor.findUnique({ where: { id } });
+        if (!precursor) return res.status(404).json({ error: 'Precursor not found' });
+        return res.status(200).json(precursor);
+      } catch (error) {
+        console.error('GET /api/precursors/[id] error', error);
+        return res.status(500).json({ error: 'Failed to fetch precursor' });
+      }
+    }
+    case 'PUT': {
+      const { title, description, pattern, modelData } = req.body || {};
+      try {
+        const updated = await prisma.precursor.update({
+          where: { id },
+          data: {
+            ...(title !== undefined ? { title } : {}),
+            ...(description !== undefined ? { description } : {}),
+            ...(pattern !== undefined ? { pattern } : {}),
+            ...(modelData !== undefined ? { modelData } : {}),
+          },
+        });
+        return res.status(200).json(updated);
+      } catch (error) {
+        console.error('PUT /api/precursors/[id] error', error);
+        return res.status(500).json({ error: 'Failed to update precursor' });
+      }
+    }
+    case 'DELETE': {
+      try {
+        await prisma.precursor.delete({ where: { id } });
+        return res.status(204).end();
+      } catch (error) {
+        console.error('DELETE /api/precursors/[id] error', error);
+        return res.status(500).json({ error: 'Failed to delete precursor' });
+      }
+    }
+    default:
+      res.setHeader('Allow', ['GET', 'PUT', 'DELETE']);
+      return res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+}

--- a/pages/api/precursors/index.js
+++ b/pages/api/precursors/index.js
@@ -1,0 +1,43 @@
+import { PrismaClient } from '@prisma/client';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../auth/[...nextauth]';
+
+const prisma = new PrismaClient();
+
+export default async function handler(req, res) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) return res.status(401).json({ error: 'Unauthorized' });
+
+  switch (req.method) {
+    case 'GET': {
+      try {
+        const precursors = await prisma.precursor.findMany({
+          select: { id: true, title: true },
+          orderBy: { createdAt: 'desc' },
+        });
+        return res.status(200).json(precursors);
+      } catch (error) {
+        console.error('GET /api/precursors error', error);
+        return res.status(500).json({ error: 'Failed to fetch precursors' });
+      }
+    }
+    case 'POST': {
+      const { title, description, pattern, modelData } = req.body || {};
+      if (!title || !pattern || !modelData) {
+        return res.status(400).json({ error: 'Missing required fields' });
+      }
+      try {
+        const created = await prisma.precursor.create({
+          data: { title, description, pattern, modelData },
+        });
+        return res.status(201).json(created);
+      } catch (error) {
+        console.error('POST /api/precursors error', error);
+        return res.status(500).json({ error: 'Failed to create precursor' });
+      }
+    }
+    default:
+      res.setHeader('Allow', ['GET', 'POST']);
+      return res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+}

--- a/src/api/precursors.js
+++ b/src/api/precursors.js
@@ -1,0 +1,38 @@
+export async function listPrecursors() {
+  const res = await fetch('/api/precursors');
+  if (!res.ok) throw new Error('Failed to fetch precursors');
+  return res.json();
+}
+
+export async function getPrecursor(id) {
+  const res = await fetch(`/api/precursors/${id}`);
+  if (!res.ok) throw new Error('Failed to fetch precursor');
+  return res.json();
+}
+
+export async function createPrecursor(data) {
+  const res = await fetch('/api/precursors', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error('Failed to create precursor');
+  return res.json();
+}
+
+export async function updatePrecursor(id, data) {
+  const res = await fetch(`/api/precursors/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error('Failed to update precursor');
+  return res.json();
+}
+
+export async function deletePrecursor(id) {
+  const res = await fetch(`/api/precursors/${id}`, {
+    method: 'DELETE',
+  });
+  if (!res.ok) throw new Error('Failed to delete precursor');
+}


### PR DESCRIPTION
## Summary
- add CRUD API routes for precursors
- expose client helpers for precursor routes
- allow notebooks to be created from precursor templates

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint pages/api/precursors pages/api/notebooks/index.js src/api/precursors.js`


------
https://chatgpt.com/codex/tasks/task_b_688e43c91934832da2a6a199d0d205cb