### PR TITLE
Add UI to create notebooks from precursors and lock template structure

### DIFF
--- a/src/components/Notebook.jsx
+++ b/src/components/Notebook.jsx
@@ -48,6 +48,7 @@ export default function Notebook() {
   const [showEdits, setShowEdits] = useState(false);
   const [showArchived, setShowArchived] = useState(false);
   const [loadError, setLoadError] = useState('');
+  const isPrecursorNotebook = !!notebook?.precursorId;
 
   const aliases = useMemo(
     () => ({
@@ -618,7 +619,7 @@ export default function Notebook() {
     }
   };
 
-  const groupsReorderable = expandedGroups.length === 0;
+  const groupsReorderable = !isPrecursorNotebook && expandedGroups.length === 0;
 
   return (
     <div className="notebook-container">
@@ -671,6 +672,7 @@ export default function Notebook() {
             >
               {notebook.groups.map((group) => {
                 const subgroupsReorderable =
+                  !isPrecursorNotebook &&
                   expandedGroups.includes(group.id) &&
                   !group.subgroups.some((s) => expandedSubgroups.includes(s.id));
                 return (
@@ -704,7 +706,7 @@ export default function Notebook() {
                             </span>
                           )}
                           <h2 className="group-title">{group.name}</h2>
-                          {expandedGroups.includes(group.id) && (
+                          {expandedGroups.includes(group.id) && !isPrecursorNotebook && (
                             <button
                               className={`edit-button${showEdits ? '' : ' hidden'}`}
                               onClick={(e) => {
@@ -782,7 +784,7 @@ export default function Notebook() {
                                             </span>
                                           )}
                                           <div className="subgroup-title">{sub.name}</div>
-                                          {expandedSubgroups.includes(sub.id) && (
+                                          {expandedSubgroups.includes(sub.id) && !isPrecursorNotebook && (
                                             <button
                                               className={`edit-button${showEdits ? '' : ' hidden'}`}
                                               onClick={(e) => {
@@ -1005,21 +1007,23 @@ export default function Notebook() {
                                   </SortableWrapper>
                                 );
                               })}
-                              <div
-                                className="add-subgroup interactive"
-                                role="button"
-                                tabIndex={0}
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  openEditor(
-                                    'subgroup',
-                                    { groupId: group.id, label: `${aliases.group}: ${group.name}` },
-                                    group.subgroups.length - 1
-                                  );
-                                }}
-                              >
-                                Add {aliases.subgroup}
-                              </div>
+                              {!isPrecursorNotebook && (
+                                <div
+                                  className="add-subgroup interactive"
+                                  role="button"
+                                  tabIndex={0}
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    openEditor(
+                                      'subgroup',
+                                      { groupId: group.id, label: `${aliases.group}: ${group.name}` },
+                                      group.subgroups.length - 1
+                                    );
+                                  }}
+                                >
+                                  Add {aliases.subgroup}
+                                </div>
+                              )}
                             </SortableContext>
                           </DndContext>
                         </div>
@@ -1028,20 +1032,22 @@ export default function Notebook() {
                   </SortableWrapper>
                 );
               })}
-              <div
-                className="add-group interactive"
-                role="button"
-                tabIndex={0}
-                onClick={() =>
-                  openEditor(
-                    'group',
-                    { label: `${aliases.group} Root` },
-                    notebook.groups.length - 1
-                  )
-                }
-              >
-                Add {aliases.group}
-              </div>
+              {!isPrecursorNotebook && (
+                <div
+                  className="add-group interactive"
+                  role="button"
+                  tabIndex={0}
+                  onClick={() =>
+                    openEditor(
+                      'group',
+                      { label: `${aliases.group} Root` },
+                      notebook.groups.length - 1
+                    )
+                  }
+                >
+                  Add {aliases.group}
+                </div>
+              )}
             </SortableContext>
           </DndContext>
         </div>

--- a/src/components/NotebookController.jsx
+++ b/src/components/NotebookController.jsx
@@ -37,12 +37,18 @@ export default function NotebookController({ onSelect, showEdits, onToggleEdits,
     onSelect(id);
   };
 
-  const handleCreate = async ({ name, description, user_notebook_tree }) => {
+  const handleCreate = async ({ name, description, user_notebook_tree, precursorId }) => {
     try {
+      const body = { title: name, description };
+      if (precursorId) {
+        body.precursorId = precursorId;
+      } else {
+        body.user_notebook_tree = user_notebook_tree;
+      }
       const res = await fetch('/api/notebooks', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ title: name, description, user_notebook_tree }),
+        body: JSON.stringify(body),
       });
       if (!res.ok) throw new Error('Failed to create notebook');
       const newNb = await res.json();


### PR DESCRIPTION
## Summary
- allow notebook creation from predefined precursors via a new selector
- send precursorId on creation and hide alias inputs when a template is chosen
- disable group/subgroup editing and structural changes on precursor-based notebooks

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_688e4c4671c4832d91c555dcee1ef45c