### PR TITLE
Add floating Pomodoro timer widget with persistence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,9 +22,11 @@
         "next": "^15.3.5",
         "next-auth": "^4.24.11",
         "react": "^18.2.0",
+        "react-circular-progressbar": "^2.2.0",
         "react-dom": "^18.2.0",
         "react-quill": "^2.0.0",
         "react-router-dom": "^7.6.3",
+        "react-timer-hook": "^4.0.5",
         "react-transition-group": "^4.4.5",
         "swr": "^2.3.4"
       },
@@ -6654,6 +6656,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-circular-progressbar": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/react-circular-progressbar/-/react-circular-progressbar-2.2.0.tgz",
+      "integrity": "sha512-cgyqEHOzB0nWMZjKfWN3MfSa1LV3OatcDjPz68lchXQUEiBD5O1WsAtoVK4/DSL0B4USR//cTdok4zCBkq8X5g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=0.14.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -6743,6 +6754,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/react-timer-hook": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/react-timer-hook/-/react-timer-hook-4.0.5.tgz",
+      "integrity": "sha512-elDxx4OIxBTbm4rXSK5cjBHkq06prO2qY9JzoYxOa11AkL3ij69jp0VuDUOqcehEK38CV0uu7FzUKtPVISRLKA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -25,9 +25,11 @@
     "next": "^15.3.5",
     "next-auth": "^4.24.11",
     "react": "^18.2.0",
+    "react-circular-progressbar": "^2.2.0",
     "react-dom": "^18.2.0",
     "react-quill": "^2.0.0",
     "react-router-dom": "^7.6.3",
+    "react-timer-hook": "^4.0.5",
     "react-transition-group": "^4.4.5",
     "swr": "^2.3.4"
   },

--- a/src/components/EntryEditor.jsx
+++ b/src/components/EntryEditor.jsx
@@ -3,6 +3,8 @@ import React, { useState, useEffect, useRef } from 'react';
 import dynamic from 'next/dynamic';
 import 'react-quill/dist/quill.snow.css';
 import { listPrecursors } from '../api/precursors';
+import { Switch } from 'antd';
+import PomodoroWidget from './PomodoroWidget';
 
 const ReactQuill = dynamic(() => import('react-quill'), { ssr: false });
 
@@ -47,6 +49,20 @@ export default function EntryEditor({
   const [headerVisible, setHeaderVisible] = useState(true);
   const [toolbarVisible, setToolbarVisible] = useState(false);
   const quillRef = useRef(null);
+  const [pomodoroEnabled, setPomodoroEnabled] = useState(false);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined' && localStorage.getItem('pomodoro-state')) {
+      setPomodoroEnabled(true);
+    }
+  }, []);
+
+  const handlePomodoroToggle = (checked) => {
+    setPomodoroEnabled(checked);
+    if (!checked) {
+      localStorage.removeItem('pomodoro-state');
+    }
+  };
 
   const quillModules = {
     toolbar: [
@@ -215,8 +231,9 @@ export default function EntryEditor({
   }, [type, title, content, parent, mode, safeData.id, onSave]);
 
   return (
-    <div className={overlayClass} onClick={handleOverlayClick}>
-      <div className={contentClass}>
+    <>
+      <div className={overlayClass} onClick={handleOverlayClick}>
+        <div className={contentClass}>
         <div
           className={`editor-header-wrapper ${type === 'entry' ? 'fullscreen' : ''}`}
           onMouseEnter={handleHeaderMouseEnter}
@@ -241,6 +258,20 @@ export default function EntryEditor({
               {type === 'tag' && (mode === 'edit' ? 'Edit Tag' : 'New Tag')}
             </h2>
             <div className="editor-modal-buttons-container">
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  marginRight: '0.5rem',
+                }}
+              >
+                <span style={{ marginRight: '0.25rem' }}>Pomodoro</span>
+                <Switch
+                  checked={pomodoroEnabled}
+                  onChange={handlePomodoroToggle}
+                  size="small"
+                />
+              </div>
               <button className="editor-button" onClick={handleSave}>
                 Save
               </button>
@@ -377,7 +408,9 @@ export default function EntryEditor({
         <div className="editor-modal-footer">
 
         </div>
+        </div>
       </div>
-    </div>
+      {pomodoroEnabled && <PomodoroWidget isFullscreen={type === 'entry'} />}
+    </>
   );
 }

--- a/src/components/PomodoroWidget.jsx
+++ b/src/components/PomodoroWidget.jsx
@@ -1,0 +1,207 @@
+import React, { useEffect, useState, useRef } from 'react';
+import { useTimer } from 'react-timer-hook';
+import { CircularProgressbar, buildStyles } from 'react-circular-progressbar';
+import 'react-circular-progressbar/dist/styles.css';
+
+export default function PomodoroWidget({ isFullscreen }) {
+  const defaultDurations = {
+    pomodoro: 25 * 60,
+    shortBreak: 5 * 60,
+    longBreak: 15 * 60,
+  };
+
+  const [durations, setDurations] = useState(defaultDurations);
+  const [currentType, setCurrentType] = useState('pomodoro');
+  const [pomodoroCount, setPomodoroCount] = useState(0);
+  const [showMenu, setShowMenu] = useState(false);
+  const menuRef = useRef(null);
+
+  const handleExpire = () => {
+    let nextType = 'pomodoro';
+    let nextCount = pomodoroCount;
+    if (currentType === 'pomodoro') {
+      nextCount += 1;
+      nextType = nextCount % 4 === 0 ? 'longBreak' : 'shortBreak';
+    }
+    setPomodoroCount(nextCount);
+    setCurrentType(nextType);
+    const nextSeconds = durations[nextType];
+    restartTimer(nextSeconds, true);
+  };
+
+  const {
+    seconds,
+    minutes,
+    isRunning,
+    pause,
+    resume,
+    restart,
+  } = useTimer({
+    expiryTimestamp: new Date(Date.now() + defaultDurations.pomodoro * 1000),
+    autoStart: false,
+    onExpire: handleExpire,
+  });
+
+  const restartTimer = (secondsLeft, autoStart) => {
+    const time = new Date(Date.now() + secondsLeft * 1000);
+    restart(time, autoStart);
+  };
+
+  useEffect(() => {
+    const saved = JSON.parse(localStorage.getItem('pomodoro-state'));
+    if (saved) {
+      setDurations(saved.durations || defaultDurations);
+      setCurrentType(saved.type || 'pomodoro');
+      setPomodoroCount(saved.pomodoroCount || 0);
+      let remaining = saved.secondsRemaining ?? defaultDurations[saved.type || 'pomodoro'];
+      if (saved.isRunning && saved.expiry) {
+        const diff = Math.floor((saved.expiry - Date.now()) / 1000);
+        remaining = diff > 0 ? diff : 0;
+      }
+      if (remaining <= 0) {
+        handleExpire();
+      } else {
+        restartTimer(remaining, saved.isRunning);
+      }
+    }
+  }, []);
+
+  const getRemainingSeconds = () => minutes * 60 + seconds;
+
+  useEffect(() => {
+    localStorage.setItem(
+      'pomodoro-state',
+      JSON.stringify({
+        type: currentType,
+        secondsRemaining: getRemainingSeconds(),
+        isRunning,
+        durations,
+        pomodoroCount,
+        expiry: isRunning ? Date.now() + getRemainingSeconds() * 1000 : null,
+      })
+    );
+  }, [isRunning, seconds, minutes, currentType, durations, pomodoroCount]);
+
+  const handleClick = () => {
+    if (isRunning) {
+      pause();
+    } else {
+      resume();
+    }
+  };
+
+  const handleContextMenu = (e) => {
+    e.preventDefault();
+    setShowMenu(true);
+  };
+
+  useEffect(() => {
+    const handleDocClick = (e) => {
+      if (menuRef.current && !menuRef.current.contains(e.target)) {
+        setShowMenu(false);
+      }
+    };
+    document.addEventListener('click', handleDocClick);
+    return () => document.removeEventListener('click', handleDocClick);
+  }, []);
+
+  const updateDuration = (type, value) => {
+    const mins = Math.max(1, Number(value));
+    const secs = mins * 60;
+    setDurations((prev) => ({ ...prev, [type]: secs }));
+    if (currentType === type) {
+      restartTimer(secs, false);
+    }
+  };
+
+  if (isFullscreen) return null;
+
+  const total = durations[currentType];
+  const remaining = getRemainingSeconds();
+  const percentage = ((total - remaining) / total) * 100;
+  const label =
+    currentType === 'pomodoro'
+      ? 'Pomodoro'
+      : currentType === 'shortBreak'
+      ? 'Short Break'
+      : 'Long Break';
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        bottom: '2rem',
+        right: '2rem',
+        width: '80px',
+        height: '80px',
+        zIndex: 9999,
+        boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
+        borderRadius: '50%',
+        background: '#fff',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        userSelect: 'none',
+        cursor: 'pointer',
+      }}
+      onClick={handleClick}
+      onContextMenu={handleContextMenu}
+    >
+      <CircularProgressbar
+        value={percentage}
+        text={`${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`}
+        styles={buildStyles({
+          pathColor: '#000',
+          trailColor: '#eee',
+          textColor: '#000',
+        })}
+      />
+      {showMenu && (
+        <div
+          ref={menuRef}
+          style={{
+            position: 'absolute',
+            bottom: '90px',
+            right: 0,
+            background: '#fff',
+            padding: '0.5rem',
+            borderRadius: '4px',
+            boxShadow: '0 2px 6px rgba(0,0,0,0.15)',
+            color: '#000',
+            fontSize: '0.8rem',
+          }}
+        >
+          <div style={{ marginBottom: '0.25rem' }}>{label}</div>
+          <label style={{ display: 'block' }}>
+            Pomodoro:
+            <input
+              type="number"
+              value={Math.floor(durations.pomodoro / 60)}
+              onChange={(e) => updateDuration('pomodoro', e.target.value)}
+              style={{ width: '3rem', marginLeft: '0.25rem' }}
+            />
+          </label>
+          <label style={{ display: 'block' }}>
+            Short:
+            <input
+              type="number"
+              value={Math.floor(durations.shortBreak / 60)}
+              onChange={(e) => updateDuration('shortBreak', e.target.value)}
+              style={{ width: '3rem', marginLeft: '0.25rem' }}
+            />
+          </label>
+          <label style={{ display: 'block' }}>
+            Long:
+            <input
+              type="number"
+              value={Math.floor(durations.longBreak / 60)}
+              onChange={(e) => updateDuration('longBreak', e.target.value)}
+              style={{ width: '3rem', marginLeft: '0.25rem' }}
+            />
+          </label>
+        </div>
+      )}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add react-timer-hook and react-circular-progressbar dependencies
- implement PomodoroWidget with circular progress, session cycling, and localStorage persistence
- integrate widget toggle into EntryEditor header

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_688e51fbaeec832db74dfed30e69ded8