### PR TITLE
Fix Pomodoro widget toggle visibility

### DIFF
--- a/src/components/EntryEditor.jsx
+++ b/src/components/EntryEditor.jsx
@@ -410,7 +410,7 @@ export default function EntryEditor({
         </div>
         </div>
       </div>
-      {pomodoroEnabled && <PomodoroWidget isFullscreen={type === 'entry'} />}
+      {pomodoroEnabled && <PomodoroWidget />}
     </>
   );
 }

--- a/src/components/PomodoroWidget.jsx
+++ b/src/components/PomodoroWidget.jsx
@@ -3,7 +3,7 @@ import { useTimer } from 'react-timer-hook';
 import { CircularProgressbar, buildStyles } from 'react-circular-progressbar';
 import 'react-circular-progressbar/dist/styles.css';
 
-export default function PomodoroWidget({ isFullscreen }) {
+export default function PomodoroWidget() {
   const defaultDurations = {
     pomodoro: 25 * 60,
     shortBreak: 5 * 60,
@@ -114,7 +114,6 @@ export default function PomodoroWidget({ isFullscreen }) {
     }
   };
 
-  if (isFullscreen) return null;
 
   const total = durations[currentType];
   const remaining = getRemainingSeconds();


### PR DESCRIPTION
## Summary
- ensure Pomodoro widget renders when toggle is enabled
- remove unused `isFullscreen` prop from widget

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/components/EntryEditor.jsx src/components/PomodoroWidget.jsx`

------
https://chatgpt.com/codex/tasks/task_b_688e5ab1fe90832da08bd0903d1938d1