### PR TITLE
Refine entry card interactions

### DIFF
--- a/src/components/Notebook.jsx
+++ b/src/components/Notebook.jsx
@@ -883,7 +883,29 @@ export default function Notebook() {
                                                           tabIndex={0}
                                                           onClick={(e) => {
                                                             e.stopPropagation();
-                                                            toggleEntry(entry.id);
+                                                            if (expandedEntries.includes(entry.id)) {
+                                                              openEditor(
+                                                                'entry',
+                                                                {
+                                                                  subgroupId: sub.id,
+                                                                  groupId: group.id,
+                                                                  entryId: entry.id,
+                                                                },
+                                                                null,
+                                                                entry,
+                                                                'edit',
+                                                                () => handleDeleteEntry(group.id, sub.id, entry.id),
+                                                                () =>
+                                                                  handleToggleArchiveEntry(
+                                                                    group.id,
+                                                                    sub.id,
+                                                                    entry.id,
+                                                                    !entry.archived
+                                                                  )
+                                                              );
+                                                            } else {
+                                                              toggleEntry(entry.id);
+                                                            }
                                                           }}
                                                         >
                                                           {entriesReorderable && (
@@ -897,6 +919,18 @@ export default function Notebook() {
                                                             </span>
                                                           )}
                                                           <h4 className="entry-card-title">{entry.title}</h4>
+                                                          {expandedEntries.includes(entry.id) && (
+                                                            <button
+                                                              className="collapse-button"
+                                                              onClick={(e) => {
+                                                                e.stopPropagation();
+                                                                toggleEntry(entry.id);
+                                                              }}
+                                                              aria-label="Collapse"
+                                                            >
+                                                              ×
+                                                            </button>
+                                                          )}
                                                           <div
                                                             className="entry-card-content"
                                                             style={{
@@ -1009,6 +1043,15 @@ export default function Notebook() {
                                                             style={{ marginLeft: '0.5rem' }}
                                                           >
                                                             {entry.archived ? 'Restore' : 'Archive'}
+                                                          </button>
+                                                          <button
+                                                            onClick={(e) => {
+                                                              e.stopPropagation();
+                                                              toggleEntry(entry.id);
+                                                            }}
+                                                            style={{ marginLeft: '0.5rem' }}
+                                                          >
+                                                            Collapse
                                                           </button>
                                                         </div>
                                                       </div>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -162,6 +162,17 @@ body {
   border-radius: 2rem;
   margin-bottom: 3rem;
   background-color: #fff;
+  position: relative;
+}
+
+.collapse-button {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  border: none;
+  background: none;
+  font-size: 1.5rem;
+  cursor: pointer;
 }
 
 .entry-card-title {


### PR DESCRIPTION
## Summary
- Open EntryEditor when clicking an already expanded entry card
- Add collapse controls at both top and bottom of entry cards
- Style collapse buttons and make entry headers position aware

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_688f7ff91af4832d98bac1c2e681cdba