### PR TITLE
Make entity cards draggable from any point

### DIFF
--- a/src/components/Notebook.jsx
+++ b/src/components/Notebook.jsx
@@ -60,7 +60,13 @@ export default function Notebook() {
     [notebook]
   );
 
-  const sensors = useSensors(useSensor(PointerSensor));
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 5,
+      },
+    })
+  );
 
   const groupRefs = useRef({});
   const subgroupRefs = useRef({});

--- a/src/components/Notebook.jsx
+++ b/src/components/Notebook.jsx
@@ -6,7 +6,6 @@ import NotebookController from './NotebookController';
 import { DndContext, PointerSensor, useSensor, useSensors, closestCenter } from '@dnd-kit/core';
 import { SortableContext, useSortable, arrayMove, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import DragHandle from '@mui/icons-material/DragHandle';
 import { Switch } from 'antd';
 
 function SortableWrapper({ id, disabled, children }) {
@@ -718,28 +717,20 @@ export default function Notebook() {
                         style={style}
                         className={`group-card ${expandedGroups.includes(group.id) ? 'open' : ''}`}
                       >
-                        <div
-                          ref={(el) => {
-                            if (el) groupRefs.current[group.id] = el;
-                          }}
-                          data-group-id={group.id}
-                          className={`group-header interactive ${
-                            activeSubgroup && activeGroup === group.id ? 'fade-out' : ''
-                          }`}
-                          role="button"
-                          tabIndex={0}
-                          onClick={() => toggleGroup(group)}
-                        >
-                          {groupsReorderable && (
-                            <span
-                              className="drag-handle"
-                              {...attributes}
-                              {...listeners}
-                              onClick={(e) => e.stopPropagation()}
-                            >
-                              <DragHandle fontSize="small" />
-                            </span>
-                          )}
+                      <div
+                        ref={(el) => {
+                          if (el) groupRefs.current[group.id] = el;
+                        }}
+                        data-group-id={group.id}
+                        className={`group-header interactive ${
+                          activeSubgroup && activeGroup === group.id ? 'fade-out' : ''
+                        }`}
+                        {...(groupsReorderable ? attributes : {})}
+                        {...(groupsReorderable ? listeners : {})}
+                        role="button"
+                        tabIndex={0}
+                        onClick={() => toggleGroup(group)}
+                      >
                           <h2 className="group-title">{group.name}</h2>
                           {expandedGroups.includes(group.id) && !isPrecursorNotebook && (
                             <button
@@ -801,6 +792,8 @@ export default function Notebook() {
                                           className={`subgroup-header interactive ${
                                             expandedSubgroups.includes(sub.id) ? 'open' : ''
                                           }`}
+                                          {...(subgroupsReorderable ? subAttr : {})}
+                                          {...(subgroupsReorderable ? subListeners : {})}
                                           role="button"
                                           tabIndex={0}
                                           onClick={(e) => {
@@ -808,16 +801,6 @@ export default function Notebook() {
                                             toggleSubgroup(sub);
                                           }}
                                         >
-                                          {subgroupsReorderable && (
-                                            <span
-                                              className="drag-handle"
-                                              {...subAttr}
-                                              {...subListeners}
-                                              onClick={(e) => e.stopPropagation()}
-                                            >
-                                              <DragHandle fontSize="small" />
-                                            </span>
-                                          )}
                                           <div className="subgroup-title">{sub.name}</div>
                                           {expandedSubgroups.includes(sub.id) && !isPrecursorNotebook && (
                                             <button
@@ -877,48 +860,40 @@ export default function Notebook() {
                                                           expandedEntries.includes(entry.id) ? 'open' : ''
                                                         } ${entry.archived ? 'archived' : ''}`}
                                                       >
-                                                        <div
-                                                          className="entry-header interactive"
-                                                          role="button"
-                                                          tabIndex={0}
-                                                          onClick={(e) => {
-                                                            e.stopPropagation();
-                                                            if (expandedEntries.includes(entry.id)) {
-                                                              openEditor(
-                                                                'entry',
-                                                                {
-                                                                  subgroupId: sub.id,
-                                                                  groupId: group.id,
-                                                                  entryId: entry.id,
-                                                                },
-                                                                null,
-                                                                entry,
-                                                                'edit',
-                                                                () => handleDeleteEntry(group.id, sub.id, entry.id),
-                                                                () =>
-                                                                  handleToggleArchiveEntry(
-                                                                    group.id,
-                                                                    sub.id,
-                                                                    entry.id,
-                                                                    !entry.archived
-                                                                  )
-                                                              );
-                                                            } else {
-                                                              toggleEntry(entry.id);
-                                                            }
-                                                          }}
-                                                        >
-                                                          {entriesReorderable && (
-                                                            <span
-                                                              className="drag-handle"
-                                                              {...entryAttr}
-                                                              {...entryListeners}
-                                                              onClick={(e) => e.stopPropagation()}
-                                                            >
-                                                              <DragHandle fontSize="small" />
-                                                            </span>
-                                                          )}
-                                                          <h4 className="entry-card-title">{entry.title}</h4>
+                                                      <div
+                                                        className="entry-header interactive"
+                                                        {...(entriesReorderable ? entryAttr : {})}
+                                                        {...(entriesReorderable ? entryListeners : {})}
+                                                        role="button"
+                                                        tabIndex={0}
+                                                        onClick={(e) => {
+                                                          e.stopPropagation();
+                                                          if (expandedEntries.includes(entry.id)) {
+                                                            openEditor(
+                                                              'entry',
+                                                              {
+                                                                subgroupId: sub.id,
+                                                                groupId: group.id,
+                                                                entryId: entry.id,
+                                                              },
+                                                              null,
+                                                              entry,
+                                                              'edit',
+                                                              () => handleDeleteEntry(group.id, sub.id, entry.id),
+                                                              () =>
+                                                                handleToggleArchiveEntry(
+                                                                  group.id,
+                                                                  sub.id,
+                                                                  entry.id,
+                                                                  !entry.archived
+                                                                )
+                                                            );
+                                                          } else {
+                                                            toggleEntry(entry.id);
+                                                          }
+                                                        }}
+                                                      >
+                                                        <h4 className="entry-card-title">{entry.title}</h4>
                                                           {expandedEntries.includes(entry.id) && (
                                                             <button
                                                               className="collapse-button"

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -511,6 +511,10 @@ body {
 .interactive,
 button {
   transition: transform 0.2s ease-in-out, filter 0.2s ease-in-out, margin-left 0.2s ease-in-out;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 .interactive:hover {
@@ -519,17 +523,6 @@ button {
   filter: brightness(0.95);
   margin-left: 0.5rem;
   max-width: 96%;
-}
-
-.drag-handle {
-  cursor: grab;
-  display: inline-flex;
-  align-items: center;
-  margin-right: 0.5rem;
-}
-
-.drag-handle:active {
-  cursor: grabbing;
 }
 
 button:hover {


### PR DESCRIPTION
## Summary
- Remove drag handle icons and attach drag listeners to the whole entity card header
- Prevent text selection on interactive elements for smoother dragging

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688ff1995318832da158362f02e84614