### PR TITLE
fix: avoid prisma update in Google sign-in

### DIFF
--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -77,24 +77,21 @@ export const authOptions = {
   },
 
   callbacks: {
-    async signIn({ user, account, profile }) {
-      if (account?.provider === 'google' && profile?.sub) {
-        await prisma.user.update({
-          where: { id: user.id },
-          data: { googleId: profile.sub },
-        });
-      }
-      return true;
-    },
-    async jwt({ token, user }) {
+    async jwt({ token, user, account, profile }) {
       if (user) {
         token.id = user.id;
+      }
+      if (account?.provider === 'google' && profile?.sub) {
+        token.googleId = profile.sub;
       }
       return token;
     },
     async session({ session, token }) {
       if (session.user && token.id) {
         session.user.id = token.id;
+      }
+      if (token.googleId) {
+        session.user.googleId = token.googleId;
       }
       return session;
     },


### PR DESCRIPTION
## Summary
- avoid Prisma user update during Google sign-in to prevent missing record errors
- store Google ID on JWT and expose it on the session

## Testing
- `npm test` *(fails: Unexpected lexical declaration in case block etc.)*

------
https://chatgpt.com/codex/tasks/task_b_6892197a8658832d86bbf934b69c2517