### PR TITLE
style: hide scrollbars globally

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -6,9 +6,16 @@ body {
   margin: 0;
   background: #ffffff;
   color: #000000;
-  /* Reserve space for the vertical scrollbar so layout width
-     doesn't change when content overflows. */
-  scrollbar-gutter: stable;
+}
+
+/* Hide scrollbars across the entire app */
+* {
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
+}
+
+*::-webkit-scrollbar {
+  display: none; /* Chrome, Safari, Opera */
 }
 
 /* Global Ant Design Drawer styling */

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -8,7 +8,7 @@ body {
   color: #000000;
 }
 
-/* Hide scrollbars across the entire app */
+/* Hide scrollbars globally for a consistent experience */
 * {
   -ms-overflow-style: none; /* IE and Edge */
   scrollbar-width: none; /* Firefox */


### PR DESCRIPTION
## Summary
- remove scrollbar gutter spacing
- hide scrollbars across the entire app for a smoother Notebook experience

## Testing
- `npm test` *(fails: Unexpected lexical declaration in case block)*

------
https://chatgpt.com/codex/tasks/task_b_689224cd4e3c832da27bd0b8b2f3a513