### PR TITLE
Fix email/password login after Google auth addition

### DIFF
--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -29,15 +29,20 @@ export const authOptions = {
     CredentialsProvider({
       name: 'Credentials',
       credentials: {
-        username: { label: 'Username', type: 'text' },
+        identifier: { label: 'Username or Email', type: 'text' },
         password: { label: 'Password', type: 'password' },
       },
       async authorize(credentials) {
-        const { username, password } = credentials;
-        if (!username || !password) return null;
+        const { identifier, password } = credentials;
+        if (!identifier || !password) return null;
 
-        const user = await prisma.user.findUnique({
-          where: { username },
+        const user = await prisma.user.findFirst({
+          where: {
+            OR: [
+              { username: identifier },
+              { email: identifier },
+            ],
+          },
         });
         if (!user || !user.passwordHash) return null;
 

--- a/src/components/LandingPage.jsx
+++ b/src/components/LandingPage.jsx
@@ -1,23 +1,20 @@
 import { signIn } from "next-auth/react";
 import React, { useState } from 'react';
 
-export default function LandingPage({ onLogin }) {
-  const [username, setUsername] = useState('');
+export default function LandingPage() {
+  const [identifier, setIdentifier] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
 
-  const handleLogin = () => {
-    signIn("credentials", {
-      username,
+  const handleLogin = async () => {
+    const result = await signIn("credentials", {
+      identifier,
       password,
       redirect: false,
-    }).then(({ ok, error: signError }) => {
-      if (ok) {
-        () => onLogin();
-      } else {
-        setError(signError || "Invalid credentials");
-      }
     });
+    if (!result?.ok) {
+      setError(result?.error || "Invalid credentials");
+    }
   };
 
   return (
@@ -37,7 +34,6 @@ export default function LandingPage({ onLogin }) {
           A sensory-friendly space to capture your thoughts and ideas.
         </p>
         <button
-          onClick={onLogin}
           style={{
             padding: '0.75rem 1.5rem',
             fontSize: '1rem',
@@ -56,9 +52,9 @@ export default function LandingPage({ onLogin }) {
         <div>
           <input
             type="text"
-            placeholder="Username"
-            value={username}
-            onChange={e => setUsername(e.target.value)}
+            placeholder="Email or Username"
+            value={identifier}
+            onChange={e => setIdentifier(e.target.value)}
             style={{ width: '100%', marginBottom: '0.5rem' }}
           />
         </div>


### PR DESCRIPTION
## Summary
- allow credentials-based login by accepting either email or username
- update landing page login form to use identifier field

## Testing
- `npm test` *(fails: Unexpected lexical declaration in case block)*

------
https://chatgpt.com/codex/tasks/task_b_6892384c295c832da72ada0c5e782dba