### PR TITLE
Snap expanded nodes to top

### DIFF
--- a/src/components/Notebook.jsx
+++ b/src/components/Notebook.jsx
@@ -70,6 +70,7 @@ export default function Notebook() {
 
   const groupRefs = useRef({});
   const subgroupRefs = useRef({});
+  const entryRefs = useRef({});
   const [activeGroup, setActiveGroup] = useState(null);
   const [activeSubgroup, setActiveSubgroup] = useState(null);
 
@@ -472,8 +473,8 @@ export default function Notebook() {
   };
 
   const toggleGroup = (group) => {
+    const isOpen = expandedGroups.includes(group.id);
     setExpandedGroups((prev) => {
-      const isOpen = prev.includes(group.id);
       if (isOpen) {
         setExpandedSubgroups((subs) =>
           subs.filter((id) => !group.subgroups.some((s) => s.id === id))
@@ -488,11 +489,19 @@ export default function Notebook() {
       }
       return [...prev, group.id];
     });
+    if (!isOpen) {
+      setTimeout(() => {
+        groupRefs.current[group.id]?.scrollIntoView({
+          behavior: 'smooth',
+          block: 'start',
+        });
+      }, 0);
+    }
   };
 
   const toggleSubgroup = (subgroup) => {
+    const isOpen = expandedSubgroups.includes(subgroup.id);
     setExpandedSubgroups((prev) => {
-      const isOpen = prev.includes(subgroup.id);
       if (isOpen) {
         setExpandedEntries((ents) =>
           ents.filter((id) => !subgroup.entries.some((e) => e.id === id))
@@ -501,14 +510,29 @@ export default function Notebook() {
       }
       return [...prev, subgroup.id];
     });
+    if (!isOpen) {
+      setTimeout(() => {
+        subgroupRefs.current[subgroup.id]?.scrollIntoView({
+          behavior: 'smooth',
+          block: 'start',
+        });
+      }, 0);
+    }
   };
 
   const toggleEntry = (entryId) => {
+    const isOpen = expandedEntries.includes(entryId);
     setExpandedEntries((prev) =>
-      prev.includes(entryId)
-        ? prev.filter((id) => id !== entryId)
-        : [...prev, entryId]
+      isOpen ? prev.filter((id) => id !== entryId) : [...prev, entryId]
     );
+    if (!isOpen) {
+      setTimeout(() => {
+        entryRefs.current[entryId]?.scrollIntoView({
+          behavior: 'smooth',
+          block: 'start',
+        });
+      }, 0);
+    }
   };
 
   const handleDeleteGroup = async (groupId) => {
@@ -860,7 +884,11 @@ export default function Notebook() {
                                                       listeners: entryListeners,
                                                     }) => (
                                                       <div
-                                                        ref={setEntryRef}
+                                                        ref={(el) => {
+                                                          setEntryRef(el);
+                                                          if (el) entryRefs.current[entry.id] = el;
+                                                        }}
+                                                        data-entry-id={entry.id}
                                                         style={entryStyle}
                                                         className={`entry-card ${
                                                           expandedEntries.includes(entry.id) ? 'open' : ''

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -107,6 +107,7 @@ body[data-theme='dark'] .ant-drawer-close {
   top: 0;
   z-index: 20;
   transition: transform 0.15s ease, opacity 0.15s ease;
+  scroll-margin-top: 1rem;
 }
 
 .group-title {
@@ -132,6 +133,7 @@ body[data-theme='dark'] .ant-drawer-close {
   position: sticky;
   top: 0;
   z-index: 30;
+  scroll-margin-top: 1rem;
 }
 
 .subgroup-title {
@@ -175,6 +177,7 @@ body[data-theme='dark'] .ant-drawer-close {
   margin-top: 2rem;
   margin-left: 2rem;
   max-width: 90%;
+  scroll-margin-top: 1rem;
 }
 
 .entry-card.archived {


### PR DESCRIPTION
## Summary
- auto-scroll newly expanded groups, subgroups, and entries to the top of the viewport for better focus
- add scroll margin to keep headers visible while scrolling

## Testing
- `npm test` *(fails: Unexpected lexical declaration in case block in existing API files)*

------
https://chatgpt.com/codex/tasks/task_b_6892647e8530832da147a558a8d862f3