### PR TITLE
Fix login redirect and NextAuth URL handling

### DIFF
--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -100,8 +100,10 @@ export const authOptions = {
       }
       return session;
     },
-    async redirect() {
-      return '/index';
+    async redirect({ url, baseUrl }) {
+      if (url.startsWith('/')) return `${baseUrl}${url}`;
+      if (url.startsWith(baseUrl)) return url;
+      return baseUrl;
     }
   }
 };

--- a/src/components/LandingPage.jsx
+++ b/src/components/LandingPage.jsx
@@ -1,10 +1,12 @@
 import { signIn } from "next-auth/react";
 import React, { useState } from 'react';
+import { useRouter } from 'next/router';
 
 export default function LandingPage() {
   const [identifier, setIdentifier] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
+  const router = useRouter();
 
   const handleLogin = async () => {
     const result = await signIn("credentials", {
@@ -12,8 +14,10 @@ export default function LandingPage() {
       password,
       redirect: false,
     });
-    if (!result?.ok) {
-      setError(result?.error || "Invalid credentials");
+    if (result?.ok) {
+      router.push('/');
+    } else if (result?.error) {
+      setError(result.error || "Invalid credentials");
     }
   };
 


### PR DESCRIPTION
## Summary
- fix login flow to navigate to home after successful credential sign-in
- correct NextAuth redirect callback to build absolute URLs

## Testing
- `npm test` *(fails: Unexpected lexical declaration in case block)*

------
https://chatgpt.com/codex/tasks/task_b_689269523604832dbe74172ca45689d1