### PR TITLE
feat: add export menu for clipboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,8 @@
         "react-router-dom": "^7.6.3",
         "react-timer-hook": "^4.0.5",
         "react-transition-group": "^4.4.5",
-        "swr": "^2.3.4"
+        "swr": "^2.3.4",
+        "turndown": "^7.2.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",
@@ -980,6 +981,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@mixmark-io/domino": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/@mui/core-downloads-tracker": {
       "version": "7.2.0",
@@ -7713,6 +7720,15 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/turndown": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.0.tgz",
+      "integrity": "sha512-eCZGBN4nNNqM9Owkv9HAtWRYfLA4h909E/WGAWWBpmB275ehNhZyk87/Tpvjbp0jjNl9XwCsbe6bm6CqFsgD+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@mixmark-io/domino": "^2.2.0"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "react-router-dom": "^7.6.3",
     "react-timer-hook": "^4.0.5",
     "react-transition-group": "^4.4.5",
-    "swr": "^2.3.4"
+    "swr": "^2.3.4",
+    "turndown": "^7.2.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/src/components/EntryEditor.jsx
+++ b/src/components/EntryEditor.jsx
@@ -6,6 +6,7 @@ import { listPrecursors } from '../api/precursors';
 import { Switch, InputNumber, Drawer, Button } from 'antd';
 import { MenuOutlined } from '@ant-design/icons';
 import PomodoroWidget from './PomodoroWidget';
+import ExportMenu from './ExportMenu';
 
 const ReactQuill = dynamic(() => import('react-quill'), { ssr: false });
 
@@ -317,41 +318,44 @@ export default function EntryEditor({
           <div className="editor-modal-body">
             <>
               <div
-                className="entry-title-container"
+                className="entry-title-row"
                 style={{ maxWidth: `${maxWidth}%` }}
               >
-                {isEditingTitle ? (
-                  <input
-                    type="text"
-                    className="entry-title-input"
-                    value={titleInput}
-                    onChange={(e) => setTitleInput(e.target.value)}
-                    onBlur={() => {
-                      setTitle(titleInput);
-                      setIsEditingTitle(false);
-                    }}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter') {
+                <div className="entry-title-container">
+                  {isEditingTitle ? (
+                    <input
+                      type="text"
+                      className="entry-title-input"
+                      value={titleInput}
+                      onChange={(e) => setTitleInput(e.target.value)}
+                      onBlur={() => {
                         setTitle(titleInput);
                         setIsEditingTitle(false);
-                      }
-                    }}
-                    autoFocus
-                  />
-                ) : (
-                  <p
-                    className="entry-title-display"
-                    onClick={() => {
-                      setTitleInput(title);
-                      setIsEditingTitle(true);
-                    }}
-                  >
-                    <strong>Title:</strong> {title || 'Untitled'}
-                  </p>
-                )}
-                <div className="last-saved">
-                  Last Autosave: {lastSaved ? lastSaved.toLocaleString() : 'no autosaves yet...'}
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                          setTitle(titleInput);
+                          setIsEditingTitle(false);
+                        }
+                      }}
+                      autoFocus
+                    />
+                  ) : (
+                    <p
+                      className="entry-title-display"
+                      onClick={() => {
+                        setTitleInput(title);
+                        setIsEditingTitle(true);
+                      }}
+                    >
+                      <strong>Title:</strong> {title || 'Untitled'}
+                    </p>
+                  )}
+                  <div className="last-saved">
+                    Last Autosave: {lastSaved ? lastSaved.toLocaleString() : 'no autosaves yet...'}
+                  </div>
                 </div>
+                <ExportMenu quillRef={quillRef} content={content} />
               </div>
               <ReactQuill
                 ref={quillRef}

--- a/src/components/ExportMenu.jsx
+++ b/src/components/ExportMenu.jsx
@@ -1,0 +1,80 @@
+import React, { useMemo } from 'react';
+import { Menu } from 'antd';
+import { CopyOutlined } from '@ant-design/icons';
+import TurndownService from 'turndown';
+
+export default function ExportMenu({ quillRef, content }) {
+  const turndownService = useMemo(() => new TurndownService(), []);
+
+  const copyTextOnly = async () => {
+    try {
+      const editor = quillRef.current?.getEditor();
+      const text = editor ? editor.getText() : '';
+      await navigator.clipboard.writeText(text.trim());
+    } catch (err) {
+      console.error('Failed to copy text', err);
+    }
+  };
+
+  const copyHtml = async () => {
+    try {
+      if (navigator.clipboard && navigator.clipboard.write) {
+        const editor = quillRef.current?.getEditor();
+        const text = editor ? editor.getText() : '';
+        await navigator.clipboard.write([
+          new ClipboardItem({
+            'text/plain': new Blob([text], { type: 'text/plain' }),
+            'text/html': new Blob([content], { type: 'text/html' }),
+          }),
+        ]);
+      } else {
+        await navigator.clipboard.writeText(content);
+      }
+    } catch (err) {
+      console.error('Failed to copy HTML', err);
+    }
+  };
+
+  const copyMarkdown = async () => {
+    try {
+      const md = turndownService.turndown(content || '');
+      await navigator.clipboard.writeText(md);
+    } catch (err) {
+      console.error('Failed to copy Markdown', err);
+    }
+  };
+
+  const handleClick = (e) => {
+    if (e.key === 'text') {
+      copyTextOnly();
+    } else if (e.key === 'html') {
+      copyHtml();
+    } else if (e.key === 'markdown') {
+      copyMarkdown();
+    }
+  };
+
+  const items = [
+    {
+      key: 'copy',
+      icon: <CopyOutlined />,
+      children: [
+        { key: 'text', label: 'Text only' },
+        { key: 'html', label: 'Full HTML' },
+        { key: 'markdown', label: 'Markdown' },
+      ],
+    },
+  ];
+
+  return (
+    <Menu
+      mode="horizontal"
+      selectable={false}
+      triggerSubMenuAction="hover"
+      onClick={handleClick}
+      items={items}
+      className="export-menu"
+    />
+  );
+}
+

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -456,18 +456,33 @@ body[data-theme='dark'] .ant-drawer-close {
   box-shadow: none;
 }
 
-.entry-title-container {
+.entry-title-row {
   position: sticky;
+  top: 0;
+  display: flex;
   width: 100%;
-  max-width: 50%;
-  /* top: 0.5rem; */
-  padding-left: 1rem;
   background: #fff;
   z-index: 10;
-  /* display: flex;
-  flex-direction: column;
-  align-items: flex-start; */
+}
+
+.entry-title-container {
+  flex: 1;
+  padding-left: 1rem;
   min-height: 0;
+}
+
+.export-menu {
+  height: 100%;
+  border-bottom: none;
+  background: transparent;
+  display: flex;
+  align-items: center;
+}
+
+.export-menu .ant-menu-submenu-title {
+  height: 100%;
+  display: flex;
+  align-items: center;
 }
 
 .entry-title-display {


### PR DESCRIPTION
## Summary
- add copy/export menu with text, HTML, and Markdown options
- inline export menu with entry title
- style title row and export menu

## Testing
- `npm test` *(fails: Unexpected lexical declaration in case block)*

------
https://chatgpt.com/codex/tasks/task_b_6892706e3fdc832d8e57b0e94e03a4eb