### PR TITLE
Add notebook edit/delete button

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -92,6 +92,11 @@ body[data-theme='dark'] .ant-drawer-close {
   font-weight: 800;
 }
 
+.notebook-title-row {
+  display: flex;
+  align-items: center;
+}
+
 .groups-container {
   margin-top: 1rem;
 }


### PR DESCRIPTION
## Summary
- allow editing and deleting notebooks via new button beside the title
- remove inline title editing
- style notebook title row with flex layout

## Testing
- `npm test` *(fails: Unexpected lexical declaration in case block in API route files)*

------
https://chatgpt.com/codex/tasks/task_b_689278416e2c832da3e8e362ac97287d