### PR TITLE
Add Terms of Service and Privacy Policy pages

### DIFF
--- a/pages/privacy.js
+++ b/pages/privacy.js
@@ -1,0 +1,37 @@
+import React from 'react';
+
+export default function Privacy() {
+  return (
+    <div style={{ padding: '2rem', maxWidth: '800px', margin: '0 auto' }}>
+      <h1>Privacy Policy</h1>
+      <p>Last updated: March 19, 2025</p>
+
+      <h2>1. Data We Collect</h2>
+      <p>We collect information you provide when creating an account such as username, email, and an optional password. For password accounts we store a bcrypt hash of the password. If you sign in with Google, we receive your name, email, and Google ID. We also store the notebooks, groups, subgroups, entries, tags, and preferences you create, along with session tokens and linked OAuth account data.</p>
+
+      <h2>2. How We Use Data</h2>
+      <p>Your information is used to operate and secure the Service, personalize editor settings, and communicate with you.</p>
+
+      <h2>3. Data Sharing and Disclosure</h2>
+      <p>Your data is stored in a PostgreSQL database and is not shared with third parties except for authentication providers such as Google. Hosting and analytics providers may process data on our behalf to run the Service.</p>
+
+      <h2>4. Data Security</h2>
+      <p>We protect your data using industry-standard practices including hashed passwords and HTTPS.</p>
+
+      <h2>5. Your Rights</h2>
+      <p>You may request access to, correction of, or deletion of your data by contacting us.</p>
+
+      <h2>6. Data Retention</h2>
+      <p>We retain data for as long as your account is active or as needed to provide the Service. We may also retain certain information to comply with legal obligations.</p>
+
+      <h2>7. International Transfers</h2>
+      <p>Your data may be transferred to and stored on servers located outside your jurisdiction.</p>
+
+      <h2>8. Changes to this Policy</h2>
+      <p>We may update this Privacy Policy from time to time. Continued use of the Service after changes constitutes acceptance of the new policy.</p>
+
+      <h2>9. Contact</h2>
+      <p>For privacy questions, contact us at privacy@inmywords.app.</p>
+    </div>
+  );
+}

--- a/pages/terms.js
+++ b/pages/terms.js
@@ -1,0 +1,43 @@
+import React from 'react';
+
+export default function Terms() {
+  return (
+    <div style={{ padding: '2rem', maxWidth: '800px', margin: '0 auto' }}>
+      <h1>Terms of Service</h1>
+      <p>Last updated: March 19, 2025</p>
+
+      <h2>1. Acceptance of Terms</h2>
+      <p>By creating an account or using InMyWords ("Service"), you agree to these Terms of Service. If you do not agree, do not use the Service.</p>
+
+      <h2>2. Accounts and Security</h2>
+      <p>To access the Service you must provide a username and email. If you register with a password, we store a bcrypt hash of your password. You are responsible for keeping your credentials secure and for activity under your account.</p>
+
+      <h2>3. User Content</h2>
+      <p>You retain ownership of the notebooks, groups, subgroups, entries, tags, and preferences you create. You grant us permission to store and process this content solely to provide the Service.</p>
+
+      <h2>4. Third‑Party Services</h2>
+      <p>We use third‑party authentication providers such as Google. When you sign in with Google, we receive your basic profile information (name, email, Google ID) to create or link your account. Google’s use of this data is governed by their own policies.</p>
+
+      <h2>5. Privacy</h2>
+      <p>Your use of the Service is subject to our <a href="/privacy">Privacy Policy</a>.</p>
+
+      <h2>6. Acceptable Use</h2>
+      <p>You agree not to misuse the Service or attempt to access it using a method other than the interface and instructions we provide.</p>
+
+      <h2>7. Termination</h2>
+      <p>We may suspend or terminate your access to the Service at any time if you violate these terms.</p>
+
+      <h2>8. Disclaimer</h2>
+      <p>The Service is provided "as is" without warranties of any kind.</p>
+
+      <h2>9. Limitation of Liability</h2>
+      <p>To the fullest extent permitted by law, we are not liable for any indirect, incidental, or consequential damages arising from your use of the Service.</p>
+
+      <h2>10. Changes to Terms</h2>
+      <p>We may update these terms from time to time. Continued use of the Service after changes constitutes acceptance of the new terms.</p>
+
+      <h2>11. Contact</h2>
+      <p>For questions about these terms, contact us at support@inmywords.app.</p>
+    </div>
+  );
+}

--- a/src/components/LandingPage.jsx
+++ b/src/components/LandingPage.jsx
@@ -1,6 +1,7 @@
 import { signIn } from "next-auth/react";
 import React, { useState } from 'react';
 import { useRouter } from 'next/router';
+import { Checkbox } from 'antd';
 
 export default function LandingPage() {
   const [identifier, setIdentifier] = useState('');
@@ -70,6 +71,11 @@ export default function LandingPage() {
             onChange={e => setPassword(e.target.value)}
             style={{ width: '100%', marginBottom: '1rem' }}
           />
+        </div>
+        <div style={{ marginBottom: '1rem' }}>
+          <Checkbox>
+            I agree to the <a href="/terms" target="_blank" rel="noopener noreferrer">Terms of Service</a> and <a href="/privacy" target="_blank" rel="noopener noreferrer">Privacy Policy</a>
+          </Checkbox>
         </div>
         <div>
           <button onClick={handleLogin} style={{ marginRight: '0.5rem' }}>


### PR DESCRIPTION
## Summary
- add dedicated Terms of Service and Privacy Policy pages
- link agreements from LandingPage with AntD checkbox

## Testing
- `npm test` *(fails: Unexpected lexical declaration in case block)*

------
https://chatgpt.com/codex/tasks/task_b_6892cb7b8928832d98fe434fdbee3192