### PR TITLE
Enable moving entries across subgroups

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -198,6 +198,10 @@ body[data-theme='dark'] .ant-drawer-close {
   margin-left: 2rem;
 }
 
+.drop-target {
+  outline: 2px dashed #4a90e2;
+}
+
 .entry-header {
   padding: 2rem;
   border: 1px solid rgba(0, 0, 0, 0.3);


### PR DESCRIPTION
## Summary
- support dragging entries between different subgroups and groups
- automatically expand target groups on entry hover and update entry ordering
- visually highlight drop targets during drag operations

## Testing
- `npm test` *(fails: `pages/api/groups/[id].js:34:9 Unexpected lexical declaration in case block no-case-declarations` and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_b_6893953b9adc832d940244c6ae33de70