### PR TITLE
feat: allow editing entry subgroup

### DIFF
--- a/src/components/EntryEditor.jsx
+++ b/src/components/EntryEditor.jsx
@@ -484,7 +484,21 @@ export default function EntryEditor({
               {type === 'entry' && groups.length > 0 && (
                 <Select
                   value={selectedSubgroupId}
-                  onChange={(val) => setSelectedSubgroupId(val)}
+                  onChange={(val) => {
+                    setSelectedSubgroupId(val);
+                    if (mode === 'edit') {
+                      onSave({
+                        title: title.trim(),
+                        content: content.trim(),
+                        parent,
+                        mode,
+                        id: safeData.id,
+                        subgroupId: val,
+                        autoSave: true,
+                      });
+                      setLastSaved(new Date());
+                    }
+                  }}
                   options={subgroupOptions}
                   size="small"
                 />

--- a/src/components/Notebook.jsx
+++ b/src/components/Notebook.jsx
@@ -1328,6 +1328,7 @@ export default function Notebook() {
           initialData={editorState.item}
           mode={editorState.mode}
           aliases={aliases}
+          groups={editorState.groups || []}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- allow changing an entry's parent subgroup from the fullscreen editor
- wire notebook editor to provide subgroups to the entry editor

## Testing
- `npm test` *(fails: Unexpected lexical declaration in case block)*

------
https://chatgpt.com/codex/tasks/task_b_6894027978f0832d8480c4de5dec5d3d