### PR TITLE
Collapse previous subgroup when another opens

### DIFF
--- a/src/components/Notebook.jsx
+++ b/src/components/Notebook.jsx
@@ -663,16 +663,16 @@ export default function Notebook() {
 
   const toggleSubgroup = (subgroup) => {
     const isOpen = expandedSubgroups.includes(subgroup.id);
-    setExpandedSubgroups((prev) => {
-      if (isOpen) {
-        setExpandedEntries((ents) =>
-          ents.filter((id) => !subgroup.entries.some((e) => e.id === id))
-        );
-        return prev.filter((id) => id !== subgroup.id);
-      }
-      return [...prev, subgroup.id];
-    });
-    if (!isOpen) {
+    if (isOpen) {
+      setExpandedSubgroups((prev) => prev.filter((id) => id !== subgroup.id));
+      setExpandedEntries((ents) =>
+        ents.filter((id) => !subgroup.entries.some((e) => e.id === id))
+      );
+    } else {
+      setExpandedSubgroups([subgroup.id]);
+      setExpandedEntries((ents) =>
+        ents.filter((id) => subgroup.entries.some((e) => e.id === id))
+      );
       setTimeout(() => {
         subgroupRefs.current[subgroup.id]?.scrollIntoView({
           behavior: 'smooth',


### PR DESCRIPTION
## Summary
- ensure only one subgroup can be expanded at a time in Notebook view

## Testing
- `npm test` *(fails: Unexpected lexical declaration in case block; 25 errors)*

------
https://chatgpt.com/codex/tasks/task_b_6894056e4a48832d84ef9b8e1fd10fff