### PR TITLE
feat: preload editor with title and padding

### DIFF
--- a/src/components/EntryEditor.jsx
+++ b/src/components/EntryEditor.jsx
@@ -163,7 +163,8 @@ export default function EntryEditor({
 
   useEffect(() => {
     if (type !== 'entry') return;
-    const editor = quillRef.current?.getEditor();
+    const editor =
+      quillRef.current?.getEditor?.() || quillRef.current;
     if (!editor) return;
     const padding = '<p><br/></p>'.repeat(PADDING_LINES);
     const html = `<h1>${title}</h1><p><br/></p>${content}${padding}`;
@@ -175,7 +176,8 @@ export default function EntryEditor({
 
   const handleSave = () => {
     if (type === 'entry') {
-      const editor = quillRef.current?.getEditor();
+      const editor =
+        quillRef.current?.getEditor?.() || quillRef.current;
       const clean = stripEditorWrappers(editor?.root.innerHTML || '');
       if (!title.trim() || !clean.trim()) {
         alert('Title and content cannot be empty.');
@@ -290,7 +292,8 @@ export default function EntryEditor({
   useEffect(() => {
     if (type !== 'entry' || mode === 'create') return;
     const interval = setInterval(() => {
-      const editor = quillRef.current?.getEditor();
+      const editor =
+        quillRef.current?.getEditor?.() || quillRef.current;
       const clean = editor ? stripEditorWrappers(editor.root.innerHTML) : content;
       onSave({
         title: title.trim(),

--- a/src/components/EntryEditor.jsx
+++ b/src/components/EntryEditor.jsx
@@ -165,7 +165,7 @@ export default function EntryEditor({
     if (type !== 'entry') return;
     const editor =
       quillRef.current?.getEditor?.() || quillRef.current;
-    if (!editor) return;
+    if (!editor || !editor.clipboard) return;
     const padding = '<p><br/></p>'.repeat(PADDING_LINES);
     const html = `<h1>${title}</h1><p><br/></p>${content}${padding}`;
     const delta = editor.clipboard.convert(html);
@@ -178,7 +178,7 @@ export default function EntryEditor({
     if (type === 'entry') {
       const editor =
         quillRef.current?.getEditor?.() || quillRef.current;
-      const clean = stripEditorWrappers(editor?.root.innerHTML || '');
+      const clean = stripEditorWrappers(editor?.root?.innerHTML || '');
       if (!title.trim() || !clean.trim()) {
         alert('Title and content cannot be empty.');
         return;

--- a/src/components/ExportMenu.jsx
+++ b/src/components/ExportMenu.jsx
@@ -10,7 +10,7 @@ export default function ExportMenu({ quillRef, content }) {
     try {
       const editor =
         quillRef.current?.getEditor?.() || quillRef.current;
-      const text = editor ? editor.getText() : '';
+      const text = editor?.getText ? editor.getText() : '';
       await navigator.clipboard.writeText(text.trim());
     } catch (err) {
       console.error('Failed to copy text', err);
@@ -22,7 +22,7 @@ export default function ExportMenu({ quillRef, content }) {
       if (navigator.clipboard && navigator.clipboard.write) {
         const editor =
           quillRef.current?.getEditor?.() || quillRef.current;
-        const text = editor ? editor.getText() : '';
+        const text = editor?.getText ? editor.getText() : '';
         await navigator.clipboard.write([
           new ClipboardItem({
             'text/plain': new Blob([text], { type: 'text/plain' }),

--- a/src/components/ExportMenu.jsx
+++ b/src/components/ExportMenu.jsx
@@ -8,7 +8,8 @@ export default function ExportMenu({ quillRef, content }) {
 
   const copyTextOnly = async () => {
     try {
-      const editor = quillRef.current?.getEditor();
+      const editor =
+        quillRef.current?.getEditor?.() || quillRef.current;
       const text = editor ? editor.getText() : '';
       await navigator.clipboard.writeText(text.trim());
     } catch (err) {
@@ -19,7 +20,8 @@ export default function ExportMenu({ quillRef, content }) {
   const copyHtml = async () => {
     try {
       if (navigator.clipboard && navigator.clipboard.write) {
-        const editor = quillRef.current?.getEditor();
+        const editor =
+          quillRef.current?.getEditor?.() || quillRef.current;
         const text = editor ? editor.getText() : '';
         await navigator.clipboard.write([
           new ClipboardItem({


### PR DESCRIPTION
## Summary
- inject entry title as H1 and pad bottom of editor with blank paragraphs
- strip injected title/padding from saved content and autosave
- keep editor focused on first content line and update title reactively

## Testing
- `npm test` *(fails: Unexpected lexical declaration in case block)*
- `npx eslint src/components/EntryEditor.jsx`


------
https://chatgpt.com/codex/tasks/task_b_689411290260832db2040d82682b05f0