### PR TITLE
Fix Pomodoro timer overlaying side drawer

### DIFF
--- a/src/components/EntryEditor.jsx
+++ b/src/components/EntryEditor.jsx
@@ -206,7 +206,6 @@ export default function EntryEditor({
     });
   };
 
-  const drawerBottomOffset = pomodoroEnabled ? 'calc(80px + 2rem)' : 0;
   const subgroupOptions = groups.flatMap((g) =>
     g.subgroups.map((s) => ({ value: s.id, label: `${g.name} / ${s.name}` }))
   );
@@ -435,14 +434,8 @@ export default function EntryEditor({
         <div
           onMouseEnter={handleDrawerMouseEnter}
           onMouseLeave={handleDrawerMouseLeave}
-          style={{
-            position: 'fixed',
-            top: 0,
-            right: 0,
-            bottom: drawerBottomOffset,
-            width: drawerWidth,
-            zIndex: 1001,
-          }}
+          className="entry-editor-drawer-wrapper"
+          style={{ width: drawerWidth }}
         >
           <Drawer
             placement="right"

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -36,6 +36,15 @@ body {
   color: #000000;
 }
 
+/* Fixed container for entry editor side drawer */
+.entry-editor-drawer-wrapper {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1001;
+}
+
 body[data-theme='dark'] .ant-drawer-content,
 body[data-theme='dark'] .ant-drawer-header {
   background-color: #1f1f1f;


### PR DESCRIPTION
## Summary
- Refactor EntryEditor drawer wrapper to extend to bottom so the Pomodoro timer floats above
- Add CSS class for fixed drawer container

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6895217118b4832d9051adaa995fa305