### PR TITLE
feat(editor): add code block format

### DIFF
--- a/src/components/EntryEditor.jsx
+++ b/src/components/EntryEditor.jsx
@@ -103,12 +103,20 @@ export default function EntryEditor({
   const quillModules = {
     toolbar: [
       [{ header: [1, 2, false] }],
-      ['bold', 'italic', 'underline'],
+      ['bold', 'italic', 'underline', 'code-block'],
       [{ list: 'bullet' }],
     ],
   };
 
-  const quillFormats = ['header', 'bold', 'italic', 'underline', 'list', 'bullet'];
+  const quillFormats = [
+    'header',
+    'bold',
+    'italic',
+    'underline',
+    'code-block',
+    'list',
+    'bullet',
+  ];
 
   // Update state when the modal is opened for a different item
   useEffect(() => {


### PR DESCRIPTION
## Summary
- enable code block formatting in Quill editor
- expose code block in editor toolbar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689528ecb43c832daa20ae355d4c2185