### PR TITLE
Add keyboard shortcut reference links and handlers

### DIFF
--- a/src/components/PomodoroWidget.jsx
+++ b/src/components/PomodoroWidget.jsx
@@ -113,6 +113,21 @@ export default function PomodoroWidget() {
     return () => document.removeEventListener('click', handleDocClick);
   }, []);
 
+  useEffect(() => {
+    const startHandler = () => {
+      resume();
+    };
+    const stopHandler = () => {
+      pause();
+    };
+    window.addEventListener('pomodoro-start', startHandler);
+    window.addEventListener('pomodoro-stop', stopHandler);
+    return () => {
+      window.removeEventListener('pomodoro-start', startHandler);
+      window.removeEventListener('pomodoro-stop', stopHandler);
+    };
+  }, [resume, pause]);
+
   const updateDuration = (type, value) => {
     const mins = Math.max(1, Number(value));
     const secs = mins * 60;


### PR DESCRIPTION
## Summary
- add global keyboard shortcuts for entry editing including save, drawer toggles and pomodoro control
- expose notebook shortcuts for creating items, full focus and edit toggle with a flyout menu
- wire pomodoro widget to start/stop events

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6895316e8d70832d980c0fad84d59765