### PR TITLE
Ensure subgroup accordion fills viewport

### DIFF
--- a/src/components/Notebook.jsx
+++ b/src/components/Notebook.jsx
@@ -687,6 +687,11 @@ export default function Notebook() {
               !group.subgroups.some((s) => s.entries.some((e) => e.id === id))
           )
         );
+        group.subgroups.forEach((s) => {
+          const el = subgroupChildrenRefs.current[s.id];
+          el?.style.removeProperty('max-height');
+          el?.style.removeProperty('min-height');
+        });
         return prev.filter((id) => id !== group.id);
       }
       return [...prev, group.id];
@@ -708,11 +713,15 @@ export default function Notebook() {
       setExpandedEntries((ents) =>
         ents.filter((id) => !subgroup.entries.some((e) => e.id === id))
       );
-      subgroupChildrenRefs.current[subgroup.id]?.style.removeProperty('max-height');
+      const el = subgroupChildrenRefs.current[subgroup.id];
+      el?.style.removeProperty('max-height');
+      el?.style.removeProperty('min-height');
     } else {
       expandedSubgroups.forEach((id) => {
         if (id !== subgroup.id) {
-          subgroupChildrenRefs.current[id]?.style.removeProperty('max-height');
+          const otherEl = subgroupChildrenRefs.current[id];
+          otherEl?.style.removeProperty('max-height');
+          otherEl?.style.removeProperty('min-height');
         }
       });
       setExpandedSubgroups([subgroup.id]);
@@ -726,7 +735,9 @@ export default function Notebook() {
         if (childrenEl) {
           childrenEl.scrollTop = 0;
           const headerHeight = headerEl?.offsetHeight || 0;
-          childrenEl.style.maxHeight = `calc(100vh - ${headerHeight}px - 2rem)`;
+          const available = window.innerHeight - headerHeight;
+          childrenEl.style.maxHeight = `${available}px`;
+          childrenEl.style.minHeight = `${available}px`;
         }
       }, 0);
     }

--- a/src/components/Notebook.jsx
+++ b/src/components/Notebook.jsx
@@ -690,7 +690,7 @@ export default function Notebook() {
         group.subgroups.forEach((s) => {
           const el = subgroupChildrenRefs.current[s.id];
           el?.style.removeProperty('max-height');
-          el?.style.removeProperty('min-height');
+          el?.style.removeProperty('height');
         });
         return prev.filter((id) => id !== group.id);
       }
@@ -715,13 +715,13 @@ export default function Notebook() {
       );
       const el = subgroupChildrenRefs.current[subgroup.id];
       el?.style.removeProperty('max-height');
-      el?.style.removeProperty('min-height');
+      el?.style.removeProperty('height');
     } else {
       expandedSubgroups.forEach((id) => {
         if (id !== subgroup.id) {
           const otherEl = subgroupChildrenRefs.current[id];
           otherEl?.style.removeProperty('max-height');
-          otherEl?.style.removeProperty('min-height');
+          otherEl?.style.removeProperty('height');
         }
       });
       setExpandedSubgroups([subgroup.id]);
@@ -737,7 +737,7 @@ export default function Notebook() {
           const headerHeight = headerEl?.offsetHeight || 0;
           const available = window.innerHeight - headerHeight;
           childrenEl.style.maxHeight = `${available}px`;
-          childrenEl.style.minHeight = `${available}px`;
+          childrenEl.style.height = `${available}px`;
         }
       }, 0);
     }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -295,6 +295,19 @@ body.dragging button {
   margin-bottom: 6rem;
 }
 
+/* Ensure open subgroup contents take full height and keep add-entry button visible */
+.subgroup-children.collapsible.open {
+  display: flex;
+  flex-direction: column;
+}
+
+.subgroup-children.collapsible.open .add-entry {
+  position: sticky;
+  bottom: 0;
+  margin-top: auto;
+  z-index: 20;
+}
+
 
 
 .editor-modal-overlay {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -874,7 +874,8 @@ body[data-theme='light'] .navbar {
 
 .collapsible.open {
   max-height: 85vh;
-  overflow: scroll;
+  overflow-y: auto;
+  overflow-x: hidden;
   scrollbar-width: none;
 }
 


### PR DESCRIPTION
## Summary
- expand open subgroups to fill the viewport and reset heights when collapsing
- use auto overflow scrolling for collapsible sections to avoid permanent scrollbars

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689605174e00832daf2f0181cae7d1d6