### PR TITLE
Add pricing scaffolding with Stripe placeholders

### DIFF
--- a/pages/api/stripe/create-checkout-session.js
+++ b/pages/api/stripe/create-checkout-session.js
@@ -1,0 +1,18 @@
+// Placeholder API route for creating a Stripe Checkout session
+// TODO: Implement actual checkout session creation
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).end('Method Not Allowed');
+  }
+
+  // In the future, use Stripe SDK to create a session with the selected price ID
+  // const { priceId } = req.body;
+  // const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
+  // const session = await stripe.checkout.sessions.create({ ... });
+  // return res.status(200).json({ url: session.url });
+
+  return res.status(501).json({ error: 'Not implemented' });
+}
+

--- a/pages/pricing.js
+++ b/pages/pricing.js
@@ -1,0 +1,86 @@
+import Head from 'next/head';
+import Script from 'next/script';
+import { Card, Button, Row, Col, List } from 'antd';
+
+const tiers = [
+  {
+    key: 'free',
+    title: 'Free',
+    price: '$0',
+    features: [
+      'Clone 1 Precursor',
+      'Create 2 Custom Aliased Notebooks',
+      'Full EntryEditor UI Features',
+    ],
+  },
+  {
+    key: 'standard',
+    title: '$5/mo.',
+    price: '$5 / month',
+    features: [
+      'Clone up to 100 Precursors',
+      'Create up to 100 Custom Aliased Notebooks',
+      'Full EntryEditor UI Features',
+      'Access to Whisker Ai Writing Companion Feature (coming soon)',
+    ],
+  },
+  {
+    key: 'pro',
+    title: '$15/mo.',
+    price: '$15 / month',
+    features: [
+      'Clone unlimited Precursors to your account',
+      'Create unlimited Custom Aliased Notebooks',
+      'Full EntryEditor UI Features',
+      'Access to Whisker Ai Writing Companion Feature (coming soon)',
+      'Access to Integration Modules',
+    ],
+  },
+];
+
+export default function PricingPage() {
+  const handleCheckout = (tier) => {
+    // TODO: Replace with Stripe Checkout session creation
+    alert(`Upgrade to ${tier} coming soon`);
+  };
+
+  return (
+    <>
+      <Head>
+        <title>Pricing | InMyWords</title>
+      </Head>
+      <div style={{ padding: '2rem' }}>
+        <Row gutter={[16, 16]} justify="center">
+          {tiers.map((tier) => (
+            <Col xs={24} sm={12} md={8} key={tier.key}>
+              <Card title={tier.title} bordered>
+                <p style={{ fontSize: '1.5rem', fontWeight: 'bold' }}>{tier.price}</p>
+                <List
+                  dataSource={tier.features}
+                  renderItem={(item) => <List.Item>{item}</List.Item>}
+                  size="small"
+                />
+                {tier.key !== 'free' && (
+                  <Button type="primary" block onClick={() => handleCheckout(tier.title)}>
+                    Choose {tier.title}
+                  </Button>
+                )}
+              </Card>
+            </Col>
+          ))}
+        </Row>
+        <div style={{ marginTop: '2rem', textAlign: 'center' }}>
+          {/* TODO: Replace with live Stripe Pricing Table embed */}
+          <Script src="https://js.stripe.com/v3/pricing-table.js" async />
+          <div style={{ maxWidth: 800, margin: '0 auto' }}>
+            <stripe-pricing-table
+              pricing-table-id="prctbl_TEST_ID"
+              publishable-key="pk_test_TESTKEY"
+            />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+

--- a/src/components/Account.jsx
+++ b/src/components/Account.jsx
@@ -105,6 +105,14 @@ export default function Account() {
         <p>Tags: {stats.tags}</p>
       </div>
 
+      <div style={{ marginBottom: '2rem' }}>
+        <h3>Subscription</h3>
+        <p>Current plan: Free</p>
+        <Button type="primary" href="/pricing">
+          Upgrade
+        </Button>
+      </div>
+
       <div
         style={{
           display: 'flex',

--- a/src/components/LandingPage.jsx
+++ b/src/components/LandingPage.jsx
@@ -28,7 +28,7 @@ export default function LandingPage() {
         <nav>
           <ul style={{ display: 'flex', listStyle: 'none', gap: '1.5rem', margin: 0, padding: 0 }}>
             <li><a href="#">Features</a></li>
-            <li><a href="#">Pricing</a></li>
+            <li><a href="/pricing">Pricing</a></li>
             <li><a href="#">About</a></li>
           </ul>
         </nav>


### PR DESCRIPTION
## Summary
- scaffold pricing tiers page with Ant Design cards and Stripe pricing-table placeholder
- add upgrade section to account page and update landing page nav link
- stub API route for future Stripe Checkout integration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68961fa3def8832d95cd9a464d9760fd