### PR TITLE
feat: add subscription fields to user

### DIFF
--- a/prisma/migrations/20250809155925_add_subscription_fields/migration.sql
+++ b/prisma/migrations/20250809155925_add_subscription_fields/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "public"."User" ADD COLUMN     "stripeCustomerId" TEXT,
+ADD COLUMN     "subscriptionPlan" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,6 +15,8 @@ model User {
   email        String       @unique
   passwordHash String?
   googleId     String?      @unique
+  stripeCustomerId String?
+  subscriptionPlan String?
   notebooks    Notebook[]   // User → Notebooks
   entries      Entry[]      // Quick access to user-owned entries
   preference   Preference?  // One-to-one user preference


### PR DESCRIPTION
## Summary
- add optional Stripe subscription fields to User model
- create and apply Prisma migration for subscription fields

## Testing
- `npm test`
- `npx prisma migrate dev --name add-subscription-fields`
- `npx prisma generate`


------
https://chatgpt.com/codex/tasks/task_b_68976f954df8832d837d48b99ec69064