### PR TITLE
refactor: introduce FullScreenCanvas for editor overlay

### DIFF
--- a/src/components/Editor/FullScreenCanvas.jsx
+++ b/src/components/Editor/FullScreenCanvas.jsx
@@ -1,0 +1,31 @@
+// src/components/Editor/FullScreenCanvas.jsx
+import React from 'react';
+
+/**
+ * Generic full screen overlay component used for editor modals.
+ * Renders children inside a full screen backdrop. Clicking the
+ * backdrop (outside of the children) triggers `onClose`.
+ */
+export default function FullScreenCanvas({
+  open = false,
+  onClose,
+  className = '',
+  children,
+}) {
+  if (!open) return null;
+
+  const overlayClass = `editor-modal-overlay fullscreen ${className}`.trim();
+
+  const handleClick = (e) => {
+    if (e.target === e.currentTarget) {
+      onClose?.();
+    }
+  };
+
+  return (
+    <div className={overlayClass} onClick={handleClick}>
+      {children}
+    </div>
+  );
+}
+

--- a/src/components/EntryEditor.jsx
+++ b/src/components/EntryEditor.jsx
@@ -7,6 +7,7 @@ import { Switch, InputNumber, Drawer, Button, Select } from 'antd';
 import { MenuOutlined } from '@ant-design/icons';
 import PomodoroWidget from './PomodoroWidget';
 import ExportMenu from './ExportMenu';
+import FullScreenCanvas from './Editor/FullScreenCanvas';
 
 const ReactQuill = dynamic(() => import('react-quill'), { ssr: false });
 
@@ -200,12 +201,6 @@ export default function EntryEditor({
     setLastSaved(new Date());
   };
 
-  // Close on background click
-  const handleOverlayClick = (e) => {
-    if (e.target === e.currentTarget) {
-      onCancel();
-    }
-  };
 
   const handleDelete = () => {
     if (onDelete) {
@@ -424,12 +419,11 @@ export default function EntryEditor({
     );
   }
 
-  const overlayClass = `editor-modal-overlay ${type === 'entry' ? 'fullscreen' : ''}`;
-  const contentClass = `editor-modal-content ${type === 'entry' ? 'fullscreen' : ''} slide-up`;
+  const contentClass = 'editor-modal-content fullscreen slide-up';
 
   return (
     <>
-      <div className={overlayClass} onClick={handleOverlayClick}>
+      <FullScreenCanvas open onClose={onCancel}>
         <div className={contentClass}>
           <div className="editor-modal-body">
             <>
@@ -589,7 +583,7 @@ export default function EntryEditor({
             </div>
           </Drawer>
         </div>
-      </div>
+      </FullScreenCanvas>
       {pomodoroEnabled && <PomodoroWidget />}
     </>
   );


### PR DESCRIPTION
## Summary
- add reusable `FullScreenCanvas` overlay component with click-to-close behaviour
- update `EntryEditor` to render its contents inside `FullScreenCanvas`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6897e22ac648832da87496ea80c716e7