### PR TITLE
refactor: decouple editor drawer

### DIFF
--- a/src/components/Drawer/Drawer.jsx
+++ b/src/components/Drawer/Drawer.jsx
@@ -1,127 +1,55 @@
-
-
 import React from 'react';
-import { Drawer as AntDrawer, Button, Switch, InputNumber, Select } from 'antd';
+import { Drawer as AntDrawer, Button } from 'antd';
 import { MenuOutlined } from '@ant-design/icons';
 
 /**
- * EditorDrawer
- * Drawer UI for entry editing controls. Pure presentational; all state/handlers
- * are passed from parent.
+ * Minimal Drawer component that provides structural slots for custom content.
  */
-export default function EditorDrawer({
-  // visibility + layout
-  drawerOpen,
-  drawerWidth = 300,
+export default function Drawer({
+  open,
+  width = 300,
   onHamburgerClick,
   onMouseEnter,
   onMouseLeave,
-
-  // editor controls
-  pomodoroEnabled,
-  onPomodoroToggle,
-  maxWidth,
-  onMaxWidthChange,
-
-  // entry context
-  type,
-  mode,
-  aliases,
-  groups = [],
-  selectedSubgroupId,
-  onChangeSubgroup, // (val) => void
-
-  // actions
-  onSave,
-  onDelete,
-  onArchive,
-  onCancel,
-
-  // keyboard help
-  showShortcutList,
-  onToggleShortcutList,
-  entryShortcuts = [],
+  header,
+  body,
+  footer,
+  children,
+  ...props
 }) {
-  const subgroupOptions = groups.flatMap((g) =>
-    g.subgroups.map((s) => ({ value: s.id, label: `${g.name} / ${s.name}` }))
-  );
-
   return (
     <>
-      <Button
-        type="text"
-        icon={<MenuOutlined />}
-        onClick={onHamburgerClick}
-        style={{ position: 'fixed', top: '1rem', right: '1rem', zIndex: 1002 }}
-      />
+      {onHamburgerClick && (
+        <Button
+          type="text"
+          icon={<MenuOutlined />}
+          onClick={onHamburgerClick}
+          style={{ position: 'fixed', top: '1rem', right: '1rem', zIndex: 1002 }}
+        />
+      )}
       <div
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
-        className="entry-editor-drawer-wrapper"
-        style={{ width: drawerWidth }}
+        className="drawer-wrapper"
+        style={{ width }}
       >
         <AntDrawer
           placement="right"
-          open={drawerOpen}
+          open={open}
           mask={false}
           closable={false}
-          width={drawerWidth}
+          width={width}
           getContainer={false}
           rootStyle={{ position: 'absolute' }}
           body={{ padding: '1rem' }}
+          {...props}
         >
-          <h2 style={{ marginTop: 0 }}>
-            {mode === 'edit' ? `Edit ${aliases.entry}` : `New ${aliases.entry}`}
-          </h2>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
-            <div style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
-              <span>Pomodoro</span>
-              <Switch checked={pomodoroEnabled} onChange={onPomodoroToggle} size="small" />
-            </div>
-            <div style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
-              <span>Max Width</span>
-              <InputNumber
-                min={25}
-                max={95}
-                step={1}
-                value={maxWidth}
-                onChange={onMaxWidthChange}
-                size="small"
-                formatter={(value) => `${value}%`}
-                parser={(value) => value.replace('%', '')}
-              />
-            </div>
-            {type === 'entry' && groups.length > 0 && (
-              <Select
-                value={selectedSubgroupId}
-                onChange={onChangeSubgroup}
-                options={subgroupOptions}
-                size="small"
-              />
-            )}
-            <Button className="drawer-btn drawer-btn-save" onClick={onSave}>Save</Button>
-            {mode === 'edit' && onDelete && (
-              <Button className="drawer-btn drawer-btn-delete" onClick={onDelete}>Delete</Button>
-            )}
-            {mode === 'edit' && onArchive && (
-              <Button className="drawer-btn drawer-btn-archive" onClick={onArchive}>
-                Archive/Restore
-              </Button>
-            )}
-            <Button className="drawer-btn drawer-btn-cancel" onClick={onCancel}>Cancel</Button>
-            <Button type="link" onClick={onToggleShortcutList}>Keyboard Shortcuts</Button>
-            {showShortcutList && (
-              <ul style={{ paddingLeft: '1rem' }}>
-                {entryShortcuts.map((s) => (
-                  <li key={s.action}>
-                    {s.action}: {s.keys}
-                  </li>
-                ))}
-              </ul>
-            )}
-          </div>
+          {header}
+          {body || children}
+          {footer}
         </AntDrawer>
       </div>
     </>
   );
 }
+

--- a/src/components/Drawer/EditorDrawer.jsx
+++ b/src/components/Drawer/EditorDrawer.jsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { Button, Switch, InputNumber, Select } from 'antd';
+import Drawer from './Drawer';
+
+/**
+ * Editor-specific drawer content built on top of the generic Drawer component.
+ */
+export default function EditorDrawer({
+  drawerOpen,
+  drawerWidth = 300,
+  onHamburgerClick,
+  onMouseEnter,
+  onMouseLeave,
+
+  pomodoroEnabled,
+  onPomodoroToggle,
+  maxWidth,
+  onMaxWidthChange,
+
+  type,
+  mode,
+  aliases,
+  groups = [],
+  selectedSubgroupId,
+  onChangeSubgroup,
+
+  onSave,
+  onDelete,
+  onArchive,
+  onCancel,
+
+  showShortcutList,
+  onToggleShortcutList,
+  entryShortcuts = [],
+}) {
+  const subgroupOptions = groups.flatMap((g) =>
+    g.subgroups.map((s) => ({ value: s.id, label: `${g.name} / ${s.name}` }))
+  );
+
+  const header = (
+    <h2 style={{ marginTop: 0 }}>
+      {mode === 'edit' ? `Edit ${aliases.entry}` : `New ${aliases.entry}`}
+    </h2>
+  );
+
+  const body = (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
+        <span>Pomodoro</span>
+        <Switch checked={pomodoroEnabled} onChange={onPomodoroToggle} size="small" />
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
+        <span>Max Width</span>
+        <InputNumber
+          min={25}
+          max={95}
+          step={1}
+          value={maxWidth}
+          onChange={onMaxWidthChange}
+          size="small"
+          formatter={(value) => `${value}%`}
+          parser={(value) => value.replace('%', '')}
+        />
+      </div>
+      {type === 'entry' && groups.length > 0 && (
+        <Select
+          value={selectedSubgroupId}
+          onChange={onChangeSubgroup}
+          options={subgroupOptions}
+          size="small"
+        />
+      )}
+      <Button className="drawer-btn drawer-btn-save" onClick={onSave}>Save</Button>
+      {mode === 'edit' && onDelete && (
+        <Button className="drawer-btn drawer-btn-delete" onClick={onDelete}>Delete</Button>
+      )}
+      {mode === 'edit' && onArchive && (
+        <Button className="drawer-btn drawer-btn-archive" onClick={onArchive}>
+          Archive/Restore
+        </Button>
+      )}
+      <Button className="drawer-btn drawer-btn-cancel" onClick={onCancel}>Cancel</Button>
+      <Button type="link" onClick={onToggleShortcutList}>Keyboard Shortcuts</Button>
+      {showShortcutList && (
+        <ul style={{ paddingLeft: '1rem' }}>
+          {entryShortcuts.map((s) => (
+            <li key={s.action}>
+              {s.action}: {s.keys}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+
+  return (
+    <Drawer
+      open={drawerOpen}
+      width={drawerWidth}
+      onHamburgerClick={onHamburgerClick}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      header={header}
+      body={body}
+    />
+  );
+}
+

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -36,8 +36,8 @@ body {
   color: #000000;
 }
 
-/* Fixed container for entry editor side drawer */
-.entry-editor-drawer-wrapper {
+/* Fixed container for side drawer */
+.drawer-wrapper {
   position: fixed;
   top: 0;
   right: 0;


### PR DESCRIPTION
## Summary
- refactor Drawer into minimal component with header/body/footer slots
- add EditorDrawer for entry editing controls
- update EntryEditor and styles to use new Drawer components

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6897e73659ac832daff1aef4c957029b