### PR TITLE
Fix build by adding JS config for path aliases

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `jsconfig.json` to configure `@` alias to `src`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6897f212089c832d90fcabbed13d9b7b