### PR TITLE
Hide tree drawer when editor fullscreen

### DIFF
--- a/src/components/Desk/DeskSurface.jsx
+++ b/src/components/Desk/DeskSurface.jsx
@@ -307,6 +307,7 @@ export default function DeskSurface({
     onDoubleClick: handleNodeDoubleClick,
     manageMode: showEdits,
     ...treePropOverrides,
+    showDrawer: !(editorState.isOpen && editorState.type === 'entry'),
   };
 
   // Editor props for NotebookEditor

--- a/src/components/Tree/NotebookTree.jsx
+++ b/src/components/Tree/NotebookTree.jsx
@@ -23,6 +23,7 @@ export default function NotebookTree({
   onAddEntry,
   onSelectItem,
   manageMode = false,
+  showDrawer = true,
   ...treeProps
 }) {
   const wrapperClasses = [
@@ -305,15 +306,17 @@ export default function NotebookTree({
           }
         }}
       />
-      <Drawer
-        open={drawerOpen}
-        width={300}
-        onHamburgerClick={handleHamburgerClick}
-        onMouseEnter={handleDrawerMouseEnter}
-        onMouseLeave={handleDrawerMouseLeave}
-        header={header}
-        body={body}
-      />
+      {showDrawer && (
+        <Drawer
+          open={drawerOpen}
+          width={300}
+          onHamburgerClick={handleHamburgerClick}
+          onMouseEnter={handleDrawerMouseEnter}
+          onMouseLeave={handleDrawerMouseLeave}
+          header={header}
+          body={body}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- allow NotebookTree drawer to be hidden
- hide NotebookTree drawer when the entry editor is open to keep fullscreen editing tools visible

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6898bbd726c8832d80af06c23aff4160