### PR TITLE
Wire add buttons to creation drawers and suppress manage drawer

### DIFF
--- a/src/components/Menu/Menu.jsx
+++ b/src/components/Menu/Menu.jsx
@@ -16,6 +16,7 @@ export default function NotebookMenu({
   onToggleEdits = () => { },
   showArchived = false,
   onToggleArchived = () => { },
+  onAddNotebookDrawerChange = () => { },
 
   // Optional additional slots
   centerContent = null,
@@ -35,6 +36,7 @@ export default function NotebookMenu({
           onToggleEdits={onToggleEdits}
           showArchived={showArchived}
           onToggleArchived={onToggleArchived}
+          onAddNotebookDrawerChange={onAddNotebookDrawerChange}
         />
       </div>
 

--- a/src/components/NotebookController.jsx
+++ b/src/components/NotebookController.jsx
@@ -6,7 +6,7 @@ import { ThemeContext } from './ThemeProvider';
 import Link from 'next/link';
 
 
-export default function NotebookController({ onSelect, showEdits, onToggleEdits, showArchived, onToggleArchived }) {
+export default function NotebookController({ onSelect, showEdits, onToggleEdits, showArchived, onToggleArchived, onAddNotebookDrawerChange }) {
   const [notebooks, setNotebooks] = useState([]);
   const [selected, setSelected] = useState('');
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -81,6 +81,10 @@ export default function NotebookController({ onSelect, showEdits, onToggleEdits,
     setNewTitle('');
     setNewDescription('');
   };
+
+  useEffect(() => {
+    onAddNotebookDrawerChange?.(drawerOpen);
+  }, [drawerOpen, onAddNotebookDrawerChange]);
 
   return (
     <div className="notebook-controller">


### PR DESCRIPTION
## Summary
- Show creation drawer for adding groups and subgroups
- Hide manage drawer while any creation drawer or entry editor is open
- Route Add Entry button to full-screen canvas editor

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6898c9fb69a4832dbe7f09842fc2a103