### PR TITLE
Expose notebook metadata editing with aliases

### DIFF
--- a/src/components/Desk/DeskSurface.jsx
+++ b/src/components/Desk/DeskSurface.jsx
@@ -420,9 +420,10 @@ export default function DeskSurface({
     onDrop,
     onSelect: handleNodeSelect,
     manageMode: showEdits,
-    onAddGroup: handleAddGroup,
-    onAddSubgroup: handleAddSubgroup,
-    onAddEntry: handleAddEntry,
+    onAddGroup: showEdits ? undefined : handleAddGroup,
+    onAddSubgroup: showEdits ? undefined : handleAddSubgroup,
+    onAddEntry: showEdits ? undefined : handleAddEntry,
+    notebookId,
     ...treePropOverrides,
     showDrawer:
       !(editorState.isOpen && editorState.type === 'entry') &&

--- a/src/components/NotebookController.jsx
+++ b/src/components/NotebookController.jsx
@@ -12,6 +12,9 @@ export default function NotebookController({ onSelect, showEdits, onToggleEdits,
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [newTitle, setNewTitle] = useState('');
   const [newDescription, setNewDescription] = useState('');
+  const [newGroupAlias, setNewGroupAlias] = useState('');
+  const [newSubgroupAlias, setNewSubgroupAlias] = useState('');
+  const [newEntryAlias, setNewEntryAlias] = useState('');
   const { darkMode, toggleTheme } = useContext(ThemeContext);
 
   useEffect(() => {
@@ -77,9 +80,16 @@ export default function NotebookController({ onSelect, showEdits, onToggleEdits,
   };
 
   const handleCreateDrawer = async () => {
-    await handleCreate({ name: newTitle, description: newDescription });
+    await handleCreate({
+      name: newTitle,
+      description: newDescription,
+      user_notebook_tree: [newGroupAlias, newSubgroupAlias, newEntryAlias],
+    });
     setNewTitle('');
     setNewDescription('');
+    setNewGroupAlias('');
+    setNewSubgroupAlias('');
+    setNewEntryAlias('');
   };
 
   useEffect(() => {
@@ -143,6 +153,24 @@ export default function NotebookController({ onSelect, showEdits, onToggleEdits,
           placeholder="Description (optional)"
           value={newDescription}
           onChange={(e) => setNewDescription(e.target.value)}
+          style={{ marginBottom: '0.5rem' }}
+        />
+        <Input
+          placeholder="Group Alias"
+          value={newGroupAlias}
+          onChange={(e) => setNewGroupAlias(e.target.value)}
+          style={{ marginBottom: '0.5rem' }}
+        />
+        <Input
+          placeholder="Subgroup Alias"
+          value={newSubgroupAlias}
+          onChange={(e) => setNewSubgroupAlias(e.target.value)}
+          style={{ marginBottom: '0.5rem' }}
+        />
+        <Input
+          placeholder="Entry Alias"
+          value={newEntryAlias}
+          onChange={(e) => setNewEntryAlias(e.target.value)}
           style={{ marginBottom: '0.5rem' }}
         />
         <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '0.5rem' }}>


### PR DESCRIPTION
## Summary
- Load notebook details when edit mode is enabled and surface title, description, and alias fields in the management drawer
- Include alias inputs when creating notebooks and persist them to user_notebook_tree
- Disable add buttons and entry selection while editing structure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6898cfc05ec8832da49d5740dd41f241