### PR TITLE
Reset drawer hover throttle when editor closes

### DIFF
--- a/src/components/Desk/DeskSurface.jsx
+++ b/src/components/Desk/DeskSurface.jsx
@@ -86,6 +86,13 @@ export default function DeskSurface({
     }, 2000);
   };
 
+  const resetManageHover = () => {
+    if (manageHoverTimeoutRef.current) {
+      clearTimeout(manageHoverTimeoutRef.current);
+    }
+    setManageHoverDisabled(false);
+  };
+
   useEffect(
     () => () => {
       if (manageHoverTimeoutRef.current) {
@@ -287,7 +294,7 @@ export default function DeskSurface({
     setTitleInput('');
     setContent('');
     setLastSaved(null);
-    throttleManageHover();
+    resetManageHover();
   };
 
   const handleSave = async (data) => {


### PR DESCRIPTION
## Summary
- Add `resetManageHover` to clear hover throttle
- Reset drawer hover throttling when closing the full screen editor

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689927dd066c832dbcff775e0f4827fe