### PR TITLE
feat: add template-based layouts for Drawer component

### DIFF
--- a/src/components/Desk/DeskSurface.jsx
+++ b/src/components/Desk/DeskSurface.jsx
@@ -9,7 +9,7 @@ import NotebookTree from '@/components/Tree/NotebookTree';
 import NotebookMenu from '@/components/Menu/Menu';
 import NotebookEditor from '@/components/Editor/NotebookEditor';
 import FullScreenCanvas from '@/components/Editor/FullScreenCanvas';
-import EditorDrawer from '@/components/Drawer/EditorDrawer';
+import Drawer from '@/components/Drawer/Drawer';
 import { Drawer as AntDrawer, Input, Button } from 'antd';
 
 function updateTreeData(list, key, children) {
@@ -495,8 +495,8 @@ export default function DeskSurface({
   ];
 
   const drawerProps = {
-    drawerOpen,
-    drawerWidth,
+    open: drawerOpen,
+    width: drawerWidth,
     onHamburgerClick: handleHamburgerClick,
     onMouseEnter: handleDrawerMouseEnter,
     onMouseLeave: handleDrawerMouseLeave,
@@ -555,7 +555,7 @@ export default function DeskSurface({
         onClose={handleCancel}
       >
         <NotebookEditor {...editorProps} />
-        <EditorDrawer {...drawerProps} />
+        <Drawer template="editor" {...drawerProps} />
       </FullScreenCanvas>
 
       <AntDrawer

--- a/src/components/Drawer/Drawer.jsx
+++ b/src/components/Drawer/Drawer.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { Drawer as AntDrawer, Button } from 'antd';
 import { MenuOutlined } from '@ant-design/icons';
+import templates from './templates';
 
 /**
- * Minimal Drawer component that provides structural slots for custom content.
+ * Flexible Drawer component that can render custom sections or
+ * predefined templates selected via the `template` prop.
  */
 export default function Drawer({
   open,
@@ -11,12 +13,24 @@ export default function Drawer({
   onHamburgerClick,
   onMouseEnter,
   onMouseLeave,
+  template,
   header,
   body,
   footer,
   children,
-  ...props
+  ...rest
 }) {
+  let sections = {
+    header,
+    body: body || children,
+    footer,
+  };
+
+  if (template && templates[template]) {
+    sections = templates[template](rest);
+    rest = {};
+  }
+
   return (
     <>
       {onHamburgerClick && (
@@ -41,12 +55,12 @@ export default function Drawer({
           width={width}
           getContainer={false}
           rootStyle={{ position: 'absolute' }}
-          body={{ padding: '1rem' }}
-          {...props}
+          bodyStyle={{ padding: '1rem' }}
+          {...rest}
         >
-          {header}
-          {body || children}
-          {footer}
+          {sections.header}
+          {sections.body}
+          {sections.footer}
         </AntDrawer>
       </div>
     </>

--- a/src/components/Drawer/templates.jsx
+++ b/src/components/Drawer/templates.jsx
@@ -1,34 +1,26 @@
 import React from 'react';
 import { Button, Switch, InputNumber, Select } from 'antd';
-import Drawer from './Drawer';
 
 /**
- * Editor-specific drawer content built on top of the generic Drawer component.
+ * Template factory functions for Drawer.
+ * Each function receives props and returns an object with
+ * header, body and optional footer elements.
  */
-export default function EditorDrawer({
-  drawerOpen,
-  drawerWidth = 300,
-  onHamburgerClick,
-  onMouseEnter,
-  onMouseLeave,
-
+export function editor({
   pomodoroEnabled,
   onPomodoroToggle,
   maxWidth,
   onMaxWidthChange,
-
   type,
   mode,
   aliases,
   groups = [],
   selectedSubgroupId,
   onChangeSubgroup,
-
   onSave,
   onDelete,
   onArchive,
   onCancel,
-
   showShortcutList,
   onToggleShortcutList,
   entryShortcuts = [],
@@ -70,17 +62,25 @@ export default function EditorDrawer({
           size="small"
         />
       )}
-      <Button className="drawer-btn drawer-btn-save" onClick={onSave}>Save</Button>
+      <Button className="drawer-btn drawer-btn-save" onClick={onSave}>
+        Save
+      </Button>
       {mode === 'edit' && onDelete && (
-        <Button className="drawer-btn drawer-btn-delete" onClick={onDelete}>Delete</Button>
+        <Button className="drawer-btn drawer-btn-delete" onClick={onDelete}>
+          Delete
+        </Button>
       )}
       {mode === 'edit' && onArchive && (
         <Button className="drawer-btn drawer-btn-archive" onClick={onArchive}>
           Archive/Restore
         </Button>
       )}
-      <Button className="drawer-btn drawer-btn-cancel" onClick={onCancel}>Cancel</Button>
-      <Button type="link" onClick={onToggleShortcutList}>Keyboard Shortcuts</Button>
+      <Button className="drawer-btn drawer-btn-cancel" onClick={onCancel}>
+        Cancel
+      </Button>
+      <Button type="link" onClick={onToggleShortcutList}>
+        Keyboard Shortcuts
+      </Button>
       {showShortcutList && (
         <ul style={{ paddingLeft: '1rem' }}>
           {entryShortcuts.map((s) => (
@@ -93,16 +93,10 @@ export default function EditorDrawer({
     </div>
   );
 
-  return (
-    <Drawer
-      open={drawerOpen}
-      width={drawerWidth}
-      onHamburgerClick={onHamburgerClick}
-      onMouseEnter={onMouseEnter}
-      onMouseLeave={onMouseLeave}
-      header={header}
-      body={body}
-    />
-  );
+  return { header, body };
 }
+
+export default {
+  editor,
+};
 


### PR DESCRIPTION
## Summary
- add `template` prop to Drawer with support for predefined layouts
- move editor-specific drawer UI into a reusable template
- replace `EditorDrawer` with `Drawer template="editor"`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68992b46d944832db8518fcdf5919866