### PR TITLE
Strip HTML from notebook preview snippets

### DIFF
--- a/src/components/Tree/NotebookTree.jsx
+++ b/src/components/Tree/NotebookTree.jsx
@@ -4,6 +4,13 @@ import { PlusOutlined } from '@ant-design/icons';
 import Drawer from '@/components/Drawer/Drawer';
 import styles from './Tree.module.css';
 
+const getPlainTextSnippet = (html, length = 200) => {
+  if (!html) return null;
+  const text = html.replace(/<[^>]+>/g, '').trim();
+  if (!text) return null;
+  return text.length > length ? `${text.slice(0, length)}...` : text;
+};
+
 /**
  * NotebookTree (Option B: Affixed context bar)
  * Adds a thin Affix bar that displays the current path (Group → Subgroup → Entry).
@@ -635,10 +642,7 @@ export default function NotebookTree({
 
             const isPreview = previewEntry && previewEntry.id === node.key;
             const snippet =
-              isPreview && previewEntry.content
-                ? previewEntry.content.slice(0, 200) +
-                (previewEntry.content.length > 200 ? '...' : '')
-                : null;
+              isPreview ? getPlainTextSnippet(previewEntry.content, 200) : null;
 
             return (
               <span className={styles.nodeContainer}>


### PR DESCRIPTION
## Summary
- Add helper to strip HTML tags and trim entry snippets
- Show plain text preview truncated to 200 chars, skip when content empty

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68993edf1bfc832db6d58fe76387589e