### PR TITLE
Toggle Pomodoro widget via drawer switch

### DIFF
--- a/src/components/Desk/DeskSurface.jsx
+++ b/src/components/Desk/DeskSurface.jsx
@@ -10,6 +10,7 @@ import NotebookEditor from '@/components/Editor/NotebookEditor';
 import FullScreenCanvas from '@/components/Editor/FullScreenCanvas';
 import Drawer from '@/components/Drawer/Drawer';
 import { Drawer as AntDrawer, Input, Button } from 'antd';
+import PomodoroWidget from '@/components/PomodoroWidget';
 
 function updateTreeData(list, key, children) {
   return list.map((node) => {
@@ -358,12 +359,16 @@ export default function DeskSurface({
   };
 
   const handlePomodoroToggle = (checked) => {
-    setPomodoroEnabled(checked);
-    const eventName = checked ? 'pomodoro-start' : 'pomodoro-stop';
-    if (typeof window !== 'undefined') {
-      window.dispatchEvent(new Event(eventName));
+    if (!checked && typeof window !== 'undefined') {
+      window.dispatchEvent(new Event('pomodoro-stop'));
     }
+    setPomodoroEnabled(checked);
   };
+
+  useEffect(() => {
+    if (!pomodoroEnabled || typeof window === 'undefined') return;
+    window.dispatchEvent(new Event('pomodoro-start'));
+  }, [pomodoroEnabled]);
 
   const handleToggleShortcutList = () => {
     setShowShortcutList((prev) => !prev);
@@ -634,6 +639,8 @@ export default function DeskSurface({
       </AntDrawer>
 
       <Drawer template="controller" {...controllerDrawerProps} />
+
+      {pomodoroEnabled && <PomodoroWidget />}
 
       {children}
     </div>

--- a/src/components/PomodoroWidget.jsx
+++ b/src/components/PomodoroWidget.jsx
@@ -114,6 +114,7 @@ export default function PomodoroWidget() {
   }, []);
 
   useEffect(() => {
+    if (typeof window === 'undefined') return;
     const startHandler = () => {
       resume();
     };


### PR DESCRIPTION
## Summary
- Conditionally render the Pomodoro widget from the desk surface and dispatch start events when enabled
- Ensure timer cleanup by firing stop events on disable and guarding event listeners in the widget

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68993fa80f10832db8e222086c3fc5e1