### PR TITLE
Extend drawer auto-close delay

### DIFF
--- a/src/components/Desk/DeskSurface.jsx
+++ b/src/components/Desk/DeskSurface.jsx
@@ -338,6 +338,7 @@ export default function DeskSurface({
   const handleDrawerMouseEnter = () => {
     if (drawerCloseTimeoutRef.current) {
       clearTimeout(drawerCloseTimeoutRef.current);
+      drawerCloseTimeoutRef.current = null;
     }
     setDrawerOpen(true);
   };
@@ -345,12 +346,13 @@ export default function DeskSurface({
   const handleDrawerMouseLeave = () => {
     if (drawerCloseTimeoutRef.current) {
       clearTimeout(drawerCloseTimeoutRef.current);
+      drawerCloseTimeoutRef.current = null;
     }
     drawerCloseTimeoutRef.current = setTimeout(() => {
       if (!drawerPinned) {
         setDrawerOpen(false);
       }
-    }, 200);
+    }, 2000);
   };
 
   const handleMaxWidthChange = (value) => {


### PR DESCRIPTION
## Summary
- keep drawer open for 2s after mouse leave before closing
- cancel drawer close timer when re-entering during delay

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689941a67900832db8ef21d3eba1f678