### PR TITLE
chore: remove keyboard shortcut listeners

### DIFF
--- a/src/components/Desk/DeskSurface.jsx
+++ b/src/components/Desk/DeskSurface.jsx
@@ -63,7 +63,6 @@ export default function DeskSurface({
   const [drawerPinned, setDrawerPinned] = useState(false);
   const drawerCloseTimeoutRef = useRef(null);
   const [pomodoroEnabled, setPomodoroEnabled] = useState(false);
-  const [showShortcutList, setShowShortcutList] = useState(false);
   const [previewEntry, setPreviewEntry] = useState(null);
   const [addDrawer, setAddDrawer] = useState({
     open: false,
@@ -372,10 +371,6 @@ export default function DeskSurface({
     window.dispatchEvent(new Event('pomodoro-start'));
   }, [pomodoroEnabled]);
 
-  const handleToggleShortcutList = () => {
-    setShowShortcutList((prev) => !prev);
-  };
-
   const handleControllerHamburgerClick = () => {
     setControllerPinned((prev) => {
       const next = !prev;
@@ -458,10 +453,6 @@ export default function DeskSurface({
     await handleSave({ title, content, subgroupId: editorState.parent?.subgroupId });
   };
 
-  const handleNotebookSaveAndClose = async () => {
-    await handleSave({ title, content, subgroupId: editorState.parent?.subgroupId });
-  };
-
   const openEntry = (node, item) => {
     setTitle(item.title || '');
     setContent(item.content || '');
@@ -523,9 +514,6 @@ export default function DeskSurface({
     content,
     setContent,
     lastSaved,
-    setLastSaved,
-    onSaveEntry: handleNotebookSave,
-    onSaveAndClose: handleNotebookSaveAndClose,
     onCancel: handleCancel,
     maxWidth,
     ...editorPropOverrides,
@@ -540,13 +528,6 @@ export default function DeskSurface({
         .filter((sg) => sg.type === 'subgroup')
         .map((sg) => ({ id: sg.key, name: sg.title })),
     }));
-
-  const entryShortcuts = [
-    { action: 'Save', keys: 'Ctrl+S' },
-    { action: 'Save & Close', keys: 'Ctrl+Shift+S' },
-    { action: 'Focus Editor', keys: 'Ctrl+Enter' },
-    { action: 'Cancel', keys: 'Esc' },
-  ];
 
   const editorDrawerProps = {
     open: drawerOpen,
@@ -568,9 +549,6 @@ export default function DeskSurface({
     onDelete: handleDelete,
     onArchive: handleArchive,
     onCancel: handleCancel,
-    showShortcutList,
-    onToggleShortcutList: handleToggleShortcutList,
-    entryShortcuts,
     ...drawerPropOverrides,
   };
 

--- a/src/components/Drawer/templates.jsx
+++ b/src/components/Drawer/templates.jsx
@@ -34,9 +34,6 @@ export function editor({
   onDelete,
   onArchive,
   onCancel,
-  showShortcutList,
-  onToggleShortcutList,
-  entryShortcuts = [],
 }) {
   const subgroupOptions = groups.flatMap((g) =>
     g.subgroups.map((s) => ({ value: s.id, label: `${g.name} / ${s.name}` }))
@@ -91,18 +88,6 @@ export function editor({
       <Button className="drawer-btn drawer-btn-cancel" onClick={onCancel}>
         Cancel
       </Button>
-      <Button type="link" onClick={onToggleShortcutList}>
-        Keyboard Shortcuts
-      </Button>
-      {showShortcutList && (
-        <ul style={{ paddingLeft: '1rem' }}>
-          {entryShortcuts.map((s) => (
-            <li key={s.action}>
-              {s.action}: {s.keys}
-            </li>
-          ))}
-        </ul>
-      )}
     </div>
   );
 

--- a/src/components/Editor/NotebookEditor.jsx
+++ b/src/components/Editor/NotebookEditor.jsx
@@ -1,5 +1,5 @@
 // src/components/Editor/NotebookEditor.jsx
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import dynamic from 'next/dynamic';
 import ExportMenu from '../ExportMenu';
 import 'react-quill/dist/quill.snow.css';
@@ -21,11 +21,8 @@ export default function NotebookEditor({
   content,
   setContent,
   lastSaved,
-  setLastSaved,
 
   // actions provided by parent
-  onSaveEntry,        // () => void  (save with current state)
-  onSaveAndClose,     // () => void  (save then close)
   onCancel,           // () => void  (close without save)
 
   // presentation
@@ -65,29 +62,6 @@ export default function NotebookEditor({
     }
   };
 
-  // keyboard shortcuts (editor-specific only)
-  useEffect(() => {
-    const onKey = (e) => {
-      const key = e.key.toLowerCase();
-      if (e.ctrlKey && !e.shiftKey && !e.altKey && key === 's') {
-        e.preventDefault();
-        onSaveEntry();
-        setLastSaved?.(new Date());
-      } else if (e.ctrlKey && e.shiftKey && !e.altKey && key === 's') {
-        e.preventDefault();
-        onSaveAndClose();
-        setLastSaved?.(new Date());
-      } else if (!e.ctrlKey && !e.altKey && e.key === 'Escape') {
-        e.preventDefault();
-        onCancel();
-      } else if (e.ctrlKey && !e.altKey && e.key === 'Enter') {
-        e.preventDefault();
-        quillRef.current?.getEditor?.().focus();
-      }
-    };
-    document.addEventListener('keydown', onKey);
-    return () => document.removeEventListener('keydown', onKey);
-  }, [onSaveEntry, onSaveAndClose, onCancel]);
 
   const overlayClass = 'editor-modal-overlay fullscreen';
   const contentClass = 'editor-modal-content fullscreen slide-up';


### PR DESCRIPTION
## Summary
- remove document keydown listeners from NotebookEditor
- drop keyboard shortcut list/link from editor drawer template
- prune shortcut-related state and props in DeskSurface

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689947acb128832d83276491a4fcd4b1