### PR TITLE
Add separate save actions to editor drawer

### DIFF
--- a/src/components/Desk/DeskSurface.jsx
+++ b/src/components/Desk/DeskSurface.jsx
@@ -323,7 +323,6 @@ export default function DeskSurface({
     } catch (err) {
       console.error('Save failed', err);
     }
-    handleCancel();
   };
 
 
@@ -456,10 +455,12 @@ export default function DeskSurface({
 
   const handleNotebookSave = async () => {
     await handleSave({ title, content, subgroupId: editorState.parent?.subgroupId });
+    setLastSaved(new Date());
   };
 
   const handleNotebookSaveAndClose = async () => {
     await handleSave({ title, content, subgroupId: editorState.parent?.subgroupId });
+    handleCancel();
   };
 
   const openEntry = (node, item) => {
@@ -545,7 +546,7 @@ export default function DeskSurface({
     { action: 'Save', keys: 'Ctrl+S' },
     { action: 'Save & Close', keys: 'Ctrl+Shift+S' },
     { action: 'Focus Editor', keys: 'Ctrl+Enter' },
-    { action: 'Cancel', keys: 'Esc' },
+    { action: 'Close without Saving', keys: 'Esc' },
   ];
 
   const editorDrawerProps = {
@@ -565,6 +566,7 @@ export default function DeskSurface({
     selectedSubgroupId: editorState.parent?.subgroupId,
     onChangeSubgroup: handleChangeSubgroup,
     onSave: handleNotebookSave,
+    onSaveAndClose: handleNotebookSaveAndClose,
     onDelete: handleDelete,
     onArchive: handleArchive,
     onCancel: handleCancel,

--- a/src/components/Drawer/templates.jsx
+++ b/src/components/Drawer/templates.jsx
@@ -31,6 +31,7 @@ export function editor({
   selectedSubgroupId,
   onChangeSubgroup,
   onSave,
+  onSaveAndClose,
   onDelete,
   onArchive,
   onCancel,
@@ -78,6 +79,9 @@ export function editor({
       <Button className="drawer-btn drawer-btn-save" onClick={onSave}>
         Save
       </Button>
+      <Button className="drawer-btn drawer-btn-save" onClick={onSaveAndClose}>
+        Save and Close
+      </Button>
       {mode === 'edit' && onDelete && (
         <Button className="drawer-btn drawer-btn-delete" onClick={onDelete}>
           Delete
@@ -89,7 +93,7 @@ export function editor({
         </Button>
       )}
       <Button className="drawer-btn drawer-btn-cancel" onClick={onCancel}>
-        Cancel
+        Close without Saving
       </Button>
       <Button type="link" onClick={onToggleShortcutList}>
         Keyboard Shortcuts


### PR DESCRIPTION
## Summary
- Add standalone **Save** and **Save and Close** buttons to the editor drawer and rename cancel to **Close without Saving**
- Split save logic in `DeskSurface` into `handleNotebookSave` and `handleNotebookSaveAndClose` to support both actions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6899493ef0c0832d822ecb068264e597