### PR TITLE
feat(tree): show notebook metadata

### DIFF
--- a/src/components/Tree/NotebookTree.jsx
+++ b/src/components/Tree/NotebookTree.jsx
@@ -11,6 +11,8 @@ const getPlainTextSnippet = (html, length = 200) => {
   return text.length > length ? `${text.slice(0, length)}...` : text;
 };
 
+const formatDate = (date) => (date ? new Date(date).toLocaleDateString() : '');
+
 /**
  * NotebookTree (Option B: Affixed context bar)
  * Adds a thin Affix bar that displays the current path (Group → Subgroup → Entry).
@@ -51,6 +53,8 @@ export default function NotebookTree({
   const [selectedItem, setSelectedItem] = useState(null);
   const [formValues, setFormValues] = useState({});
   const [notebookTitle, setNotebookTitle] = useState('');
+  const [createdAt, setCreatedAt] = useState('');
+  const [updatedAt, setUpdatedAt] = useState('');
 
   useEffect(() => {
     if (manageMode) {
@@ -67,6 +71,8 @@ export default function NotebookTree({
   useEffect(() => {
     if (!notebookId) {
       setNotebookTitle('');
+      setCreatedAt('');
+      setUpdatedAt('');
       return;
     }
     fetch(`/api/notebooks/${notebookId}`)
@@ -74,6 +80,8 @@ export default function NotebookTree({
       .then((nb) => {
         if (nb) {
           setNotebookTitle(nb.title || '');
+          setCreatedAt(nb.createdAt || '');
+          setUpdatedAt(nb.updatedAt || '');
           if (manageMode) {
             setFormValues({
               title: nb.title || '',
@@ -554,6 +562,20 @@ export default function NotebookTree({
   // Render
   return (
     <div className={wrapperClasses} style={style}>
+      {notebookTitle && (
+        <header className={styles.header}>
+          <h2 className={styles.headerTitle}>{notebookTitle}</h2>
+          <div className={styles.meta}>
+            {createdAt && (
+              <time dateTime={createdAt}>{formatDate(createdAt)}</time>
+            )}
+            {updatedAt && (
+              <time dateTime={updatedAt}>{formatDate(updatedAt)}</time>
+            )}
+          </div>
+        </header>
+      )}
+
       {/* Affixed context bar */}
       <Affix offsetTop={affixOffsetTop}>
         <div
@@ -581,9 +603,6 @@ export default function NotebookTree({
 
       {/* Tree */}
       <div style={{ marginTop: 8, ...treeWidthStyle }}>
-        {notebookTitle && (
-          <h2 style={{ margin: '0 0 8px 0' }}>{notebookTitle}</h2>
-        )}
         <Tree
           {...restTreeProps}
           style={treeStyle}

--- a/src/components/Tree/Tree.module.css
+++ b/src/components/Tree/Tree.module.css
@@ -64,3 +64,19 @@
   outline: 1px dashed color-mix(in oklab, var(--ant-colorText) 25%, transparent);
   outline-offset: 3px;
 }
+
+.header {
+  margin-bottom: 1rem;
+}
+
+.headerTitle {
+  margin: 0;
+}
+
+.meta {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+  font-size: 0.75rem;
+  color: var(--ant-colorTextSecondary);
+}


### PR DESCRIPTION
## Summary
- display notebook title, creation date, and last update in a minimalist header
- fetch createdAt and updatedAt alongside notebook title
- add simple header styling to keep black/white theme

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689a1f4dea94832db8f38373c7c4a17f