### PR TITLE
fix: ensure neon branch deletion

### DIFF
--- a/.github/workflows/neon_workflow.yml
+++ b/.github/workflows/neon_workflow.yml
@@ -82,7 +82,7 @@ jobs:
   delete_neon_branch:
     name: Delete Neon Branch
     needs: setup
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    if: github.event.action == 'closed'
     runs-on: ubuntu-latest
     steps:
       - name: Delete Neon Branch


### PR DESCRIPTION
## Summary
- simplify delete branch workflow so neon preview branches are removed on PR closure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689a5834f8d0832daec4340fae8cd8b5