### PR TITLE
feat: add entry card action toolbar

### DIFF
--- a/src/components/Desk/DeskSurface.jsx
+++ b/src/components/Desk/DeskSurface.jsx
@@ -20,6 +20,13 @@ function updateTreeData(list, key, children) {
   });
 }
 
+function getPlainTextSnippet(html, length = 200) {
+  if (!html) return null;
+  const text = html.replace(/<[^>]+>/g, '').trim();
+  if (!text) return null;
+  return text.length > length ? `${text.slice(0, length)}...` : text;
+}
+
 /**
  * DeskSurface
  * Pure layout + lifted state. Holds top-level state/handlers formerly in NotebookDev.jsx
@@ -185,8 +192,11 @@ export default function DeskSurface({
               origin,
               node.key,
               filtered.map((e) => ({
+                id: e.id,
                 title: e.title,
                 key: e.id,
+                snippet: getPlainTextSnippet(e.content),
+                content: e.content,
                 isLeaf: true,
                 type: 'entry',
                 subgroupId: node.key,
@@ -211,8 +221,11 @@ export default function DeskSurface({
             origin,
             subgroupId,
             filtered.map((e) => ({
+              id: e.id,
               title: e.title,
               key: e.id,
+              snippet: getPlainTextSnippet(e.content),
+              content: e.content,
               isLeaf: true,
               type: 'entry',
               subgroupId,
@@ -507,6 +520,14 @@ export default function DeskSurface({
     });
   };
 
+  const handleEditEntry = async (entry) => {
+    const res = await fetch(`/api/entries/${entry.id}`);
+    const item = res.ok
+      ? await res.json()
+      : { id: entry.id, title: entry.title, content: '' };
+    openEntry(entry, item);
+  };
+
   const handleNodeSelect = async (keys, info) => {
     const node = info.node;
     if (node.type !== 'entry') return;
@@ -532,6 +553,7 @@ export default function DeskSurface({
     onAddGroup: showEdits ? undefined : handleAddGroup,
     onAddSubgroup: showEdits ? undefined : handleAddSubgroup,
     onAddEntry: showEdits ? undefined : handleAddEntry,
+    onEdit: showEdits ? undefined : handleEditEntry,
     notebookId,
     previewEntry,
     ...treePropOverrides,

--- a/src/components/Tree/EntryCard.jsx
+++ b/src/components/Tree/EntryCard.jsx
@@ -1,33 +1,101 @@
 import React, { forwardRef } from 'react';
+import { Button } from 'antd';
 import { AnimatePresence, motion as Motion } from 'framer-motion';
 import styles from './Tree.module.css';
 
-const EntryCard = forwardRef(
-  ({ title, snippet, isOpen, onToggle }, ref) => (
+const EntryCard = forwardRef(({ entry, isOpen, onToggle, onEdit }, ref) => {
+  const handleEdit = (e) => {
+    e.stopPropagation();
+    onEdit?.(entry);
+  };
+
+  const handleArchive = async (e) => {
+    e.stopPropagation();
+    await fetch(`/api/entries/${entry.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ archived: true }),
+    });
+  };
+
+  const handleDelete = async (e) => {
+    e.stopPropagation();
+    await fetch(`/api/entries/${entry.id}`, { method: 'DELETE' });
+  };
+
+  const handleDuplicate = async (e) => {
+    e.stopPropagation();
+    const res = await fetch(`/api/entries/${entry.id}`);
+    if (!res.ok) return;
+    const data = await res.json();
+    await fetch('/api/entries', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: data.title,
+        content: data.content,
+        subgroupId: data.subgroupId,
+        tagIds: data.tags?.map((t) => t.id),
+      }),
+    });
+  };
+
+  const handleAddTag = async (e) => {
+    e.stopPropagation();
+    const tagId = window.prompt('Enter tag ID');
+    if (!tagId) return;
+    const res = await fetch(`/api/entries/${entry.id}`);
+    if (!res.ok) return;
+    const data = await res.json();
+    const ids = data.tags?.map((t) => t.id) || [];
+    if (ids.includes(tagId)) return;
+    ids.push(tagId);
+    await fetch(`/api/entries/${entry.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tagIds: ids }),
+    });
+  };
+
+  return (
     <div ref={ref} style={{ marginBottom: '0.5rem' }}>
-      <div
-        className={styles.entryTitle}
-        style={{ cursor: 'pointer' }}
-        onClick={onToggle}
-      >
-        {title}
+      <div className={styles.entryTitle} style={{ cursor: 'pointer' }} onClick={onToggle}>
+        {entry.title}
       </div>
       <AnimatePresence initial={false}>
-        {isOpen && snippet && (
+        {isOpen && (
           <Motion.div
             initial={{ height: 0, opacity: 0 }}
             animate={{ height: 'auto', opacity: 1 }}
             exit={{ height: 0, opacity: 0 }}
             transition={{ duration: 0.2 }}
             style={{ overflow: 'hidden', marginLeft: '1rem' }}
+            onClick={() => onEdit?.(entry)}
           >
-            <p className={styles.entrySnippet}>{snippet}</p>
+            {entry.snippet && <p className={styles.entrySnippet}>{entry.snippet}</p>}
+            <div className={styles.entryActions} onClick={(e) => e.stopPropagation()}>
+              <Button size="small" onClick={handleEdit}>
+                Edit
+              </Button>
+              <Button size="small" onClick={handleArchive}>
+                Archive
+              </Button>
+              <Button size="small" onClick={handleDelete}>
+                Delete
+              </Button>
+              <Button size="small" onClick={handleDuplicate}>
+                Duplicate
+              </Button>
+              <Button size="small" onClick={handleAddTag}>
+                Add Tag
+              </Button>
+            </div>
           </Motion.div>
         )}
       </AnimatePresence>
     </div>
-  )
-);
+  );
+});
 
 export default EntryCard;
 

--- a/src/components/Tree/NotebookTree.jsx
+++ b/src/components/Tree/NotebookTree.jsx
@@ -5,14 +5,6 @@ import SubgroupCard from './SubgroupCard';
 import EntryCard from './EntryCard';
 import styles from './Tree.module.css';
 
-// Utility helpers preserved from previous implementation
-const getPlainTextSnippet = (html, length = 200) => {
-  if (!html) return null;
-  const text = html.replace(/<[^>]+>/g, '').trim();
-  if (!text) return null;
-  return text.length > length ? `${text.slice(0, length)}...` : text;
-};
-
 const formatDate = (date) => (date ? new Date(date).toLocaleDateString() : '');
 
 /**
@@ -25,6 +17,7 @@ export default function NotebookTree({
   onAddGroup,
   onAddSubgroup,
   onAddEntry,
+  onEdit,
   notebookId,
   loadData,
 }) {
@@ -134,11 +127,11 @@ export default function NotebookTree({
               {sub.children?.map((entry) => (
                 <EntryCard
                   key={entry.key}
-                  ref={(el) => (entryRefs.current[entry.key] = el)}
-                  title={entry.title}
-                  snippet={getPlainTextSnippet(entry.content)}
-                  isOpen={openEntryId === entry.key}
-                  onToggle={() => handleEntryToggle(entry.key)}
+                  ref={(el) => (entryRefs.current[entry.id] = el)}
+                  entry={entry}
+                  isOpen={openEntryId === entry.id}
+                  onToggle={() => handleEntryToggle(entry.id)}
+                  onEdit={onEdit}
                 />
               ))}
               {onAddEntry && (

--- a/src/components/Tree/Tree.module.css
+++ b/src/components/Tree/Tree.module.css
@@ -43,6 +43,12 @@
   margin-top: 0.5rem;
 }
 
+.entryActions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
 /* Hover + selected states mapped to theme vars */
 .root :where(.ant-tree) .ant-tree-node-content-wrapper:hover {
   background: var(--ant-controlItemBgHover);


### PR DESCRIPTION
## Summary
- show snippet and action buttons when an entry card is expanded
- support editing, archiving, deleting, duplicating, and tagging entries via API
- launch the full-screen editor from expanded cards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689a6f977514832db53f8e4ef19492c9