### PR TITLE
refactor: add dedicated add buttons

### DIFF
--- a/src/components/Tree/AddEntryButton.jsx
+++ b/src/components/Tree/AddEntryButton.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { Button } from 'antd';
+
+export default function AddEntryButton({ groupKey, subgroupKey, subgroupTitle, onAddEntry }) {
+  return (
+    <Button type="dashed" onClick={() => onAddEntry(groupKey, subgroupKey)}>
+      {`Add New Entry to Subgroup ${subgroupTitle}`}
+    </Button>
+  );
+}
+

--- a/src/components/Tree/AddGroupButton.jsx
+++ b/src/components/Tree/AddGroupButton.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { Button } from 'antd';
+
+export default function AddGroupButton({ onAddGroup }) {
+  return (
+    <Button type="dashed" onClick={onAddGroup} style={{ marginTop: '1rem' }}>
+      Add New Group
+    </Button>
+  );
+}
+

--- a/src/components/Tree/AddSubgroupButton.jsx
+++ b/src/components/Tree/AddSubgroupButton.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { Button } from 'antd';
+
+export default function AddSubgroupButton({ groupKey, groupTitle, onAddSubgroup }) {
+  return (
+    <Button type="dashed" onClick={() => onAddSubgroup(groupKey)}>
+      {`Add New Subgroup to ${groupTitle}`}
+    </Button>
+  );
+}
+

--- a/src/components/Tree/NotebookTree.jsx
+++ b/src/components/Tree/NotebookTree.jsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Button } from 'antd';
 import GroupCard from './GroupCard';
 import SubgroupCard from './SubgroupCard';
 import EntryCard from './EntryCard';
+import AddGroupButton from './AddGroupButton';
+import AddSubgroupButton from './AddSubgroupButton';
+import AddEntryButton from './AddEntryButton';
 import styles from './Tree.module.css';
 
 const formatDate = (date) => (date ? new Date(date).toLocaleDateString() : '');
@@ -135,24 +137,25 @@ export default function NotebookTree({
                 />
               ))}
               {onAddEntry && (
-                <Button type="dashed" onClick={() => onAddEntry(group.key, sub.key)}>
-                  Add entry
-                </Button>
+                <AddEntryButton
+                  groupKey={group.key}
+                  subgroupKey={sub.key}
+                  subgroupTitle={sub.title}
+                  onAddEntry={onAddEntry}
+                />
               )}
             </SubgroupCard>
           ))}
           {onAddSubgroup && (
-            <Button type="dashed" onClick={() => onAddSubgroup(group.key)}>
-              Add subgroup
-            </Button>
+            <AddSubgroupButton
+              groupKey={group.key}
+              groupTitle={group.title}
+              onAddSubgroup={onAddSubgroup}
+            />
           )}
         </GroupCard>
       ))}
-      {onAddGroup && (
-        <Button type="dashed" onClick={onAddGroup} style={{ marginTop: '1rem' }}>
-          Add group
-        </Button>
-      )}
+      {onAddGroup && <AddGroupButton onAddGroup={onAddGroup} />}
     </div>
   );
 }

--- a/src/components/Tree/NotebookTree.test.jsx
+++ b/src/components/Tree/NotebookTree.test.jsx
@@ -27,8 +27,37 @@ describe('NotebookTree custom cards', () => {
     const user = userEvent.setup();
     const onAddGroup = jest.fn();
     render(<NotebookTree treeData={[]} onAddGroup={onAddGroup} />);
-    await user.click(screen.getByRole('button', { name: /add group/i }));
+    await user.click(screen.getByRole('button', { name: /add new group/i }));
     expect(onAddGroup).toHaveBeenCalled();
+  });
+
+  it('calls onAddSubgroup when button is clicked', async () => {
+    const user = userEvent.setup();
+    const onAddSubgroup = jest.fn();
+    const treeData = [{ title: 'Group 1', key: 'g1', children: [] }];
+    render(
+      <NotebookTree treeData={treeData} onAddSubgroup={onAddSubgroup} />
+    );
+    await user.click(screen.getByText('Group 1'));
+    await user.click(
+      screen.getByRole('button', { name: /add new subgroup to group 1/i })
+    );
+    expect(onAddSubgroup).toHaveBeenCalledWith('g1');
+  });
+
+  it('calls onAddEntry when button is clicked', async () => {
+    const user = userEvent.setup();
+    const onAddEntry = jest.fn();
+    const treeData = [
+      { title: 'Group 1', key: 'g1', children: [{ title: 'Sub 1', key: 's1' }] },
+    ];
+    render(<NotebookTree treeData={treeData} onAddEntry={onAddEntry} />);
+    await user.click(screen.getByText('Group 1'));
+    await user.click(screen.getByText('Sub 1'));
+    await user.click(
+      screen.getByRole('button', { name: /add new entry to subgroup sub 1/i })
+    );
+    expect(onAddEntry).toHaveBeenCalledWith('g1', 's1');
   });
 });
 


### PR DESCRIPTION
## Summary
- replace inline add buttons with AddGroupButton, AddSubgroupButton, and AddEntryButton
- display context-aware labels using parent titles
- test that new buttons trigger corresponding handlers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689a74f89188832dae9a8d02e086bacd