### PR TITLE
feat: add sortable notebook tree

### DIFF
--- a/src/components/Desk/DeskSurface.jsx
+++ b/src/components/Desk/DeskSurface.jsx
@@ -545,9 +545,9 @@ export default function DeskSurface({
   // Tree props to pass to wrapper component
   const treeProps = {
     showLine: true,
-    draggable: true,
     loadData,
     treeData,
+    setTreeData,
     onSelect: handleNodeSelect,
     manageMode: showEdits,
     onAddGroup: showEdits ? undefined : handleAddGroup,

--- a/src/components/Tree/EntryCard.jsx
+++ b/src/components/Tree/EntryCard.jsx
@@ -1,9 +1,30 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useCallback } from 'react';
 import { Button } from 'antd';
 import { AnimatePresence, motion as Motion } from 'framer-motion';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import styles from './Tree.module.css';
 
-const EntryCard = forwardRef(({ entry, isOpen, onToggle, onEdit }, ref) => {
+const EntryCard = forwardRef(
+  ({ id, entry, isOpen, onToggle, onEdit, disableDrag }, ref) => {
+    const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
+      id,
+      disabled: disableDrag,
+    });
+    const style = {
+      transform: CSS.Transform.toString(transform),
+      transition,
+      marginBottom: '0.5rem',
+    };
+    const mergedRef = useCallback(
+      (node) => {
+        setNodeRef(node);
+        if (typeof ref === 'function') ref(node);
+        else if (ref) ref.current = node;
+      },
+      [ref, setNodeRef]
+    );
+
   const handleEdit = (e) => {
     e.stopPropagation();
     onEdit?.(entry);
@@ -58,8 +79,14 @@ const EntryCard = forwardRef(({ entry, isOpen, onToggle, onEdit }, ref) => {
   };
 
   return (
-    <div ref={ref} style={{ marginBottom: '0.5rem' }}>
-      <div className={styles.entryTitle} style={{ cursor: 'pointer' }} onClick={onToggle}>
+    <div ref={mergedRef} style={style}>
+      <div
+        className={styles.entryTitle}
+        style={{ cursor: 'pointer' }}
+        onClick={onToggle}
+        {...attributes}
+        {...listeners}
+      >
         {entry.title}
       </div>
       <AnimatePresence initial={false}>

--- a/src/components/Tree/GroupCard.jsx
+++ b/src/components/Tree/GroupCard.jsx
@@ -1,31 +1,57 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useCallback } from 'react';
 import { AnimatePresence, motion as Motion } from 'framer-motion';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import styles from './Tree.module.css';
 
-const GroupCard = forwardRef(({ title, isOpen, onToggle, children }, ref) => (
-  <div ref={ref} style={{ marginBottom: '1rem' }}>
-    <div
-      className={styles.groupTitle}
-      style={{ cursor: 'pointer' }}
-      onClick={onToggle}
-    >
-      {title}
-    </div>
-    <AnimatePresence initial={false}>
-      {isOpen && (
-        <Motion.div
-          initial={{ height: 0, opacity: 0 }}
-          animate={{ height: 'auto', opacity: 1 }}
-          exit={{ height: 0, opacity: 0 }}
-          transition={{ duration: 0.2 }}
-          style={{ overflow: 'hidden', marginLeft: '1rem' }}
+const GroupCard = forwardRef(
+  ({ id, title, isOpen, onToggle, children, disableDrag }, ref) => {
+    const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
+      id,
+      disabled: disableDrag,
+    });
+    const style = {
+      transform: CSS.Transform.toString(transform),
+      transition,
+      marginBottom: '1rem',
+    };
+    const mergedRef = useCallback(
+      (node) => {
+        setNodeRef(node);
+        if (typeof ref === 'function') ref(node);
+        else if (ref) ref.current = node;
+      },
+      [ref, setNodeRef]
+    );
+
+    return (
+      <div ref={mergedRef} style={style}>
+        <div
+          className={styles.groupTitle}
+          style={{ cursor: 'pointer' }}
+          onClick={onToggle}
+          {...attributes}
+          {...listeners}
         >
-          {children}
-        </Motion.div>
-      )}
-    </AnimatePresence>
-  </div>
-));
+          {title}
+        </div>
+        <AnimatePresence initial={false}>
+          {isOpen && (
+            <Motion.div
+              initial={{ height: 0, opacity: 0 }}
+              animate={{ height: 'auto', opacity: 1 }}
+              exit={{ height: 0, opacity: 0 }}
+              transition={{ duration: 0.2 }}
+              style={{ overflow: 'hidden', marginLeft: '1rem' }}
+            >
+              {children}
+            </Motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+    );
+  }
+);
 
 export default GroupCard;
 

--- a/src/components/Tree/NotebookTree.test.jsx
+++ b/src/components/Tree/NotebookTree.test.jsx
@@ -12,7 +12,7 @@ describe('NotebookTree custom cards', () => {
       { title: 'Group 1', key: 'g1', children: [{ title: 'Sub 1', key: 's1' }] },
       { title: 'Group 2', key: 'g2', children: [{ title: 'Sub 2', key: 's2' }] },
     ];
-    render(<NotebookTree treeData={treeData} />);
+    render(<NotebookTree treeData={treeData} manageMode />);
     expect(screen.queryByText('Sub 1')).not.toBeInTheDocument();
     await user.click(screen.getByText('Group 1'));
     await screen.findByText('Sub 1');
@@ -26,7 +26,7 @@ describe('NotebookTree custom cards', () => {
   it('calls onAddGroup when add group button is clicked', async () => {
     const user = userEvent.setup();
     const onAddGroup = jest.fn();
-    render(<NotebookTree treeData={[]} onAddGroup={onAddGroup} />);
+    render(<NotebookTree treeData={[]} onAddGroup={onAddGroup} manageMode />);
     await user.click(screen.getByRole('button', { name: /add new group/i }));
     expect(onAddGroup).toHaveBeenCalled();
   });
@@ -36,7 +36,11 @@ describe('NotebookTree custom cards', () => {
     const onAddSubgroup = jest.fn();
     const treeData = [{ title: 'Group 1', key: 'g1', children: [] }];
     render(
-      <NotebookTree treeData={treeData} onAddSubgroup={onAddSubgroup} />
+      <NotebookTree
+        treeData={treeData}
+        onAddSubgroup={onAddSubgroup}
+        manageMode
+      />
     );
     await user.click(screen.getByText('Group 1'));
     await user.click(
@@ -51,7 +55,9 @@ describe('NotebookTree custom cards', () => {
     const treeData = [
       { title: 'Group 1', key: 'g1', children: [{ title: 'Sub 1', key: 's1' }] },
     ];
-    render(<NotebookTree treeData={treeData} onAddEntry={onAddEntry} />);
+    render(
+      <NotebookTree treeData={treeData} onAddEntry={onAddEntry} manageMode />
+    );
     await user.click(screen.getByText('Group 1'));
     await user.click(screen.getByText('Sub 1'));
     await user.click(

--- a/src/components/Tree/SubgroupCard.jsx
+++ b/src/components/Tree/SubgroupCard.jsx
@@ -1,32 +1,56 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useCallback } from 'react';
 import { AnimatePresence, motion as Motion } from 'framer-motion';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import styles from './Tree.module.css';
 
 const SubgroupCard = forwardRef(
-  ({ title, isOpen, onToggle, children }, ref) => (
-    <div ref={ref} style={{ marginBottom: '0.75rem' }}>
-      <div
-        className={styles.subgroupTitle}
-        style={{ cursor: 'pointer' }}
-        onClick={onToggle}
-      >
-        {title}
+  ({ id, title, isOpen, onToggle, children, disableDrag }, ref) => {
+    const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
+      id,
+      disabled: disableDrag,
+    });
+    const style = {
+      transform: CSS.Transform.toString(transform),
+      transition,
+      marginBottom: '0.75rem',
+    };
+    const mergedRef = useCallback(
+      (node) => {
+        setNodeRef(node);
+        if (typeof ref === 'function') ref(node);
+        else if (ref) ref.current = node;
+      },
+      [ref, setNodeRef]
+    );
+
+    return (
+      <div ref={mergedRef} style={style}>
+        <div
+          className={styles.subgroupTitle}
+          style={{ cursor: 'pointer' }}
+          onClick={onToggle}
+          {...attributes}
+          {...listeners}
+        >
+          {title}
+        </div>
+        <AnimatePresence initial={false}>
+          {isOpen && (
+            <Motion.div
+              initial={{ height: 0, opacity: 0 }}
+              animate={{ height: 'auto', opacity: 1 }}
+              exit={{ height: 0, opacity: 0 }}
+              transition={{ duration: 0.2 }}
+              style={{ overflow: 'hidden', marginLeft: '1rem' }}
+            >
+              {children}
+            </Motion.div>
+          )}
+        </AnimatePresence>
       </div>
-      <AnimatePresence initial={false}>
-        {isOpen && (
-          <Motion.div
-            initial={{ height: 0, opacity: 0 }}
-            animate={{ height: 'auto', opacity: 1 }}
-            exit={{ height: 0, opacity: 0 }}
-            transition={{ duration: 0.2 }}
-            style={{ overflow: 'hidden', marginLeft: '1rem' }}
-          >
-            {children}
-          </Motion.div>
-        )}
-      </AnimatePresence>
-    </div>
-  )
+    );
+  }
 );
 
 export default SubgroupCard;


### PR DESCRIPTION
## Summary
- enable drag-and-drop sorting for groups, subgroups, and entries
- persist order updates via new reorder handlers
- disable dragging while manage mode is active and adjust tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689a78fe0324832db1c0977877daea11