### PR TITLE
Expand manage mode with entity editor

### DIFF
--- a/src/components/Tree/EntityEditDrawer.jsx
+++ b/src/components/Tree/EntityEditDrawer.jsx
@@ -6,13 +6,17 @@ import { Drawer, Input, Button } from 'antd';
  * Expects `type` ('group' | 'subgroup' | 'entry') and `id`.
  */
 export default function EntityEditDrawer({ type, id, open, initialData, onClose }) {
-  const [title, setTitle] = useState(initialData?.title || '');
-  const [description, setDescription] = useState(initialData?.description || '');
+  const [title, setTitle] = useState(
+    initialData?.title ?? initialData?.name ?? ''
+  );
+  const [description, setDescription] = useState(
+    initialData?.description ?? ''
+  );
 
   useEffect(() => {
     if (!open) return;
-    setTitle(initialData?.title || '');
-    setDescription(initialData?.description || '');
+    setTitle(initialData?.title ?? initialData?.name ?? '');
+    setDescription(initialData?.description ?? '');
   }, [initialData, open]);
 
   useEffect(() => {
@@ -22,8 +26,8 @@ export default function EntityEditDrawer({ type, id, open, initialData, onClose 
       .then((res) => (res.ok ? res.json() : null))
       .then((data) => {
         if (!cancelled && data) {
-          setTitle(data.title || '');
-          setDescription(data.description || '');
+          setTitle(data.title ?? data.name ?? '');
+          setDescription(data.description ?? '');
         }
       });
     return () => {
@@ -32,10 +36,14 @@ export default function EntityEditDrawer({ type, id, open, initialData, onClose 
   }, [type, id, open]);
 
   const handleSave = async () => {
+    const payload =
+      type === 'entry'
+        ? { title, description }
+        : { name: title, description };
     await fetch(`/api/${type}s/${id}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ title, description }),
+      body: JSON.stringify(payload),
     });
     onClose?.();
   };

--- a/src/components/Tree/EntityEditDrawer.jsx
+++ b/src/components/Tree/EntityEditDrawer.jsx
@@ -35,7 +35,7 @@ export default function EntityEditDrawer({ type, id, open, onClose }) {
   };
 
   return (
-    <Drawer open={open} onClose={onClose} title={`Edit ${type}`} getContainer={false} style={{ position: 'absolute' }}>
+    <Drawer open={open} onClose={onClose} title={`Edit ${type}`} zIndex={1002}>
       <Input
         placeholder="Title"
         value={title}

--- a/src/components/Tree/EntityEditDrawer.jsx
+++ b/src/components/Tree/EntityEditDrawer.jsx
@@ -5,9 +5,15 @@ import { Drawer, Input, Button } from 'antd';
  * Simple drawer for editing an entity (group, subgroup or entry).
  * Expects `type` ('group' | 'subgroup' | 'entry') and `id`.
  */
-export default function EntityEditDrawer({ type, id, open, onClose }) {
-  const [title, setTitle] = useState('');
-  const [description, setDescription] = useState('');
+export default function EntityEditDrawer({ type, id, open, initialData, onClose }) {
+  const [title, setTitle] = useState(initialData?.title || '');
+  const [description, setDescription] = useState(initialData?.description || '');
+
+  useEffect(() => {
+    if (!open) return;
+    setTitle(initialData?.title || '');
+    setDescription(initialData?.description || '');
+  }, [initialData, open]);
 
   useEffect(() => {
     if (!open || !type || !id || typeof fetch === 'undefined') return;

--- a/src/components/Tree/EntityEditDrawer.jsx
+++ b/src/components/Tree/EntityEditDrawer.jsx
@@ -1,0 +1,59 @@
+import React, { useEffect, useState } from 'react';
+import { Drawer, Input, Button } from 'antd';
+
+/**
+ * Simple drawer for editing an entity (group, subgroup or entry).
+ * Expects `type` ('group' | 'subgroup' | 'entry') and `id`.
+ */
+export default function EntityEditDrawer({ type, id, open, onClose }) {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+
+  useEffect(() => {
+    if (!open || !type || !id || typeof fetch === 'undefined') return;
+    let cancelled = false;
+    fetch(`/api/${type}s/${id}`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (!cancelled && data) {
+          setTitle(data.title || '');
+          setDescription(data.description || '');
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [type, id, open]);
+
+  const handleSave = async () => {
+    await fetch(`/api/${type}s/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title, description }),
+    });
+    onClose?.();
+  };
+
+  return (
+    <Drawer open={open} onClose={onClose} title={`Edit ${type}`} getContainer={false} style={{ position: 'absolute' }}>
+      <Input
+        placeholder="Title"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        style={{ marginBottom: '0.5rem' }}
+      />
+      <Input.TextArea
+        placeholder="Description"
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        style={{ marginBottom: '0.5rem' }}
+      />
+      <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '0.5rem' }}>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button type="primary" onClick={handleSave}>
+          Save
+        </Button>
+      </div>
+    </Drawer>
+  );
+}

--- a/src/components/Tree/EntryCard.jsx
+++ b/src/components/Tree/EntryCard.jsx
@@ -6,7 +6,10 @@ import { CSS } from '@dnd-kit/utilities';
 import styles from './Tree.module.css';
 
 const EntryCard = forwardRef(
-  ({ id, entry, isOpen, onToggle, onEdit, disableDrag }, ref) => {
+  (
+    { id, entry, isOpen, onToggle, onEdit, disableDrag, actionsDisabled },
+    ref
+  ) => {
     const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
       id,
       disabled: disableDrag,
@@ -93,7 +96,7 @@ const EntryCard = forwardRef(
         )}
         <div
           className={styles.entryTitle}
-          style={{ cursor: 'pointer' }}
+          style={{ cursor: actionsDisabled ? 'default' : 'pointer' }}
           onClick={onToggle}
         >
           {entry.title}
@@ -110,23 +113,28 @@ const EntryCard = forwardRef(
             onClick={() => onEdit?.(entry)}
           >
             {entry.snippet && <p className={styles.entrySnippet}>{entry.snippet}</p>}
-            <div className={styles.entryActions} onClick={(e) => e.stopPropagation()}>
-              <Button size="small" onClick={handleEdit}>
-                Edit
-              </Button>
-              <Button size="small" onClick={handleArchive}>
-                Archive
-              </Button>
-              <Button size="small" onClick={handleDelete}>
-                Delete
-              </Button>
-              <Button size="small" onClick={handleDuplicate}>
-                Duplicate
-              </Button>
-              <Button size="small" onClick={handleAddTag}>
-                Add Tag
-              </Button>
-            </div>
+            {!actionsDisabled && (
+              <div
+                className={styles.entryActions}
+                onClick={(e) => e.stopPropagation()}
+              >
+                <Button size="small" onClick={handleEdit}>
+                  Edit
+                </Button>
+                <Button size="small" onClick={handleArchive}>
+                  Archive
+                </Button>
+                <Button size="small" onClick={handleDelete}>
+                  Delete
+                </Button>
+                <Button size="small" onClick={handleDuplicate}>
+                  Duplicate
+                </Button>
+                <Button size="small" onClick={handleAddTag}>
+                  Add Tag
+                </Button>
+              </div>
+            )}
           </Motion.div>
         )}
       </AnimatePresence>

--- a/src/components/Tree/NotebookTree.jsx
+++ b/src/components/Tree/NotebookTree.jsx
@@ -73,7 +73,7 @@ export default function NotebookTree({
 
   const handleGroupToggle = async (group) => {
     if (manageMode) {
-      setEditEntity({ type: 'group', id: group.key });
+      setEditEntity({ type: 'group', id: group.key, data: group });
       return;
     }
     const isCurrentlyOpen = openGroupId === group.key;
@@ -95,7 +95,7 @@ export default function NotebookTree({
 
   const handleSubgroupToggle = async (sub) => {
     if (manageMode) {
-      setEditEntity({ type: 'subgroup', id: sub.key });
+      setEditEntity({ type: 'subgroup', id: sub.key, data: sub });
       return;
     }
     const isCurrentlyOpen = openSubgroupId === sub.key;
@@ -113,13 +113,14 @@ export default function NotebookTree({
     setTimeout(() => scrollTo(subgroupRefs, sub.key), 0);
   };
 
-  const handleEntryToggle = (id) => {
+  const handleEntryToggle = (entry) => {
+    const entryId = typeof entry === 'object' ? entry.id : entry;
     if (manageMode) {
-      setEditEntity({ type: 'entry', id });
+      setEditEntity({ type: 'entry', id: entryId, data: entry });
       return;
     }
-    setOpenEntryId((prev) => (prev === id ? null : id));
-    setTimeout(() => scrollTo(entryRefs, id), 0);
+    setOpenEntryId((prev) => (prev === entryId ? null : entryId));
+    setTimeout(() => scrollTo(entryRefs, entryId), 0);
   };
 
   useEffect(() => {
@@ -286,7 +287,7 @@ export default function NotebookTree({
                                     ref={(el) => (entryRefs.current[entry.id] = el)}
                                     entry={entry}
                                     isOpen={openEntryId === entry.id}
-                                    onToggle={() => handleEntryToggle(entry.id)}
+                                    onToggle={() => handleEntryToggle(entry)}
                                     onEdit={onEdit}
                                     actionsDisabled={manageMode}
                                   />
@@ -325,6 +326,7 @@ export default function NotebookTree({
           type={editEntity.type}
           id={editEntity.id}
           open={!!editEntity}
+          initialData={editEntity.data}
           onClose={() => setEditEntity(null)}
         />
       )}


### PR DESCRIPTION
## Summary
- Auto-expand all groups and subgroups in manage mode and keep tree drawer open
- Add EntityEditDrawer for editing groups, subgroups or entries
- Disable add buttons and entry actions during manage mode

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689a8da06524832daded65e7a7040c39