### PR TITLE
Ensure drawers persist during manage mode

### DIFF
--- a/src/components/Desk/DeskSurface.jsx
+++ b/src/components/Desk/DeskSurface.jsx
@@ -96,13 +96,6 @@ export default function DeskSurface({
     }, 2000);
   };
 
-  const resetManageHover = () => {
-    if (manageHoverTimeoutRef.current) {
-      clearTimeout(manageHoverTimeoutRef.current);
-    }
-    setManageHoverDisabled(false);
-  };
-
   useEffect(
     () => () => {
       if (manageHoverTimeoutRef.current) {
@@ -339,7 +332,7 @@ export default function DeskSurface({
     setTitleInput('');
     setContent('');
     setLastSaved(null);
-    resetManageHover();
+    throttleManageHover();
   };
 
   const handleSave = async (data) => {
@@ -414,6 +407,7 @@ export default function DeskSurface({
   }, [pomodoroEnabled]);
 
   const handleControllerHamburgerClick = () => {
+    if (showEdits) return;
     setControllerPinned((prev) => {
       const next = !prev;
       setControllerOpen(next);
@@ -436,7 +430,7 @@ export default function DeskSurface({
       if (!controllerPinned && !showEdits) {
         setControllerOpen(false);
       }
-    }, 200);
+    }, 2000);
   };
 
   useEffect(() => {

--- a/src/components/Desk/DeskSurface.jsx
+++ b/src/components/Desk/DeskSurface.jsx
@@ -327,6 +327,7 @@ export default function DeskSurface({
     setEditorState({ isOpen: false, type: null, parent: null, item: null, mode: 'create' });
     setDrawerPinned(false);
     setDrawerOpen(false);
+    setControllerOpen(false);
     setIsEditingTitle(false);
     setTitle('');
     setTitleInput('');

--- a/src/components/Tree/NotebookTree.jsx
+++ b/src/components/Tree/NotebookTree.jsx
@@ -63,6 +63,32 @@ export default function NotebookTree({
   const groupRefs = useRef({});
   const subgroupRefs = useRef({});
   const entryRefs = useRef({});
+  const editDrawerHideRef = useRef(null);
+
+  const clearEditDrawerHide = () => {
+    if (editDrawerHideRef.current) {
+      clearTimeout(editDrawerHideRef.current);
+      editDrawerHideRef.current = null;
+    }
+  };
+
+  const handleEditDrawerMouseEnter = () => {
+    clearEditDrawerHide();
+  };
+
+  const handleEditDrawerMouseLeave = () => {
+    clearEditDrawerHide();
+    editDrawerHideRef.current = setTimeout(() => {
+      setEditEntity(null);
+    }, 2000);
+  };
+
+  useEffect(
+    () => () => {
+      clearEditDrawerHide();
+    },
+    []
+  );
 
   const scrollTo = (refMap, id) => {
     const node = refMap.current[id];
@@ -428,15 +454,20 @@ export default function NotebookTree({
       </DndContext>
       {!manageMode && onAddGroup && <AddGroupButton onAddGroup={onAddGroup} />}
       {editEntity && (
-        <EntityEditDrawer
-          type={editEntity.type}
-          id={editEntity.id}
-          open={!!editEntity}
-          initialData={editEntity.data}
-          subgroupOptions={editEntity.subgroups}
-          onSave={handleEntitySave}
-          onClose={() => setEditEntity(null)}
-        />
+        <div
+          onMouseEnter={handleEditDrawerMouseEnter}
+          onMouseLeave={handleEditDrawerMouseLeave}
+        >
+          <EntityEditDrawer
+            type={editEntity.type}
+            id={editEntity.id}
+            open={!!editEntity}
+            initialData={editEntity.data}
+            subgroupOptions={editEntity.subgroups}
+            onSave={handleEntitySave}
+            onClose={() => setEditEntity(null)}
+          />
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- Add ref-managed 2s hide timer for entity edit drawer
- Delay root drawer hover reactivation after full-screen editor closes
- Keep controller drawer pinned open in manage mode

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689b40e1979c832db01ae4130f50ad5c