### PR TITLE
feat: toggle archived entries

### DIFF
--- a/src/components/Desk/DeskSurface.jsx
+++ b/src/components/Desk/DeskSurface.jsx
@@ -48,6 +48,14 @@ export default function DeskSurface({
   const [treeData, setTreeData] = useState([]);
   const [showEdits, setShowEdits] = useState(false);
   const [showArchived, setShowArchived] = useState(false);
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('showArchived');
+      if (stored !== null) {
+        setShowArchived(stored === 'true');
+      }
+    }
+  }, []);
   const [reorderMode, setReorderMode] = useState(false);
   const [editorState, setEditorState] = useState({
     isOpen: false,
@@ -149,7 +157,7 @@ export default function DeskSurface({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [notebookId]);
 
-  const loadData = (node) => {
+  const loadData = (node, showArch = showArchived) => {
     const hasRealChildren =
       Array.isArray(node.children) && node.children.some((child) => child.kind !== 'add');
     if (hasRealChildren) return Promise.resolve();
@@ -178,7 +186,7 @@ export default function DeskSurface({
       return fetch(`/api/entries?subgroupId=${node.key}`)
         .then((res) => (res.ok ? res.json() : []))
         .then((entries) => {
-          const filtered = showArchived
+          const filtered = showArch
             ? entries
             : entries.filter((e) => !e.archived);
           setTreeData((origin) =>
@@ -319,6 +327,9 @@ export default function DeskSurface({
           }
         });
       });
+      if (typeof window !== 'undefined') {
+        localStorage.setItem('showArchived', next.toString());
+      }
       return next;
     });
   };
@@ -547,6 +558,7 @@ export default function DeskSurface({
     onSelect: handleNodeSelect,
     manageMode: showEdits,
     reorderMode,
+    showArchived,
     onAddGroup: showEdits ? undefined : handleAddGroup,
     onAddSubgroup: showEdits ? undefined : handleAddSubgroup,
     onAddEntry: showEdits ? undefined : handleAddEntry,

--- a/src/components/Drawer/templates.jsx
+++ b/src/components/Drawer/templates.jsx
@@ -239,7 +239,11 @@ function NotebookControllerContent({
           <span>Re-order</span>
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-          <Switch checked={showArchived} onChange={onToggleArchived} />
+          <Switch
+            checked={showArchived}
+            onChange={onToggleArchived}
+            size="small"
+          />
           <span>Show Archived</span>
         </div>
         <Avatar

--- a/src/components/Tree/NotebookTree.jsx
+++ b/src/components/Tree/NotebookTree.jsx
@@ -32,6 +32,7 @@ export default function NotebookTree({
   loadData,
   manageMode,
   reorderMode = false,
+  showArchived = false,
 }) {
   // notebook metadata
   const [notebookTitle, setNotebookTitle] = useState('');
@@ -110,7 +111,7 @@ export default function NotebookTree({
 
     // wait for data to load before expanding so children render with animation
     if (loadData) {
-      await loadData(group);
+      await loadData(group, showArchived);
     }
 
     setOpenGroupId(group.key);
@@ -131,7 +132,7 @@ export default function NotebookTree({
     }
 
     if (loadData) {
-      await loadData(sub);
+      await loadData(sub, showArchived);
     }
 
     setOpenSubgroupId(sub.key);
@@ -165,16 +166,16 @@ export default function NotebookTree({
     if (!manageMode || !loadData) return;
     async function loadAll() {
       for (const group of treeData) {
-        await loadData(group);
+        await loadData(group, showArchived);
         if (group.children) {
           for (const sub of group.children) {
-            await loadData(sub);
+            await loadData(sub, showArchived);
           }
         }
       }
     }
     loadAll();
-  }, [manageMode, loadData, treeData]);
+  }, [manageMode, loadData, treeData, showArchived]);
 
   const persistGroupOrder = (items) => {
     const orders = items.map((g, index) => ({ id: g.key, user_sort: index }));


### PR DESCRIPTION
## Summary
- allow showing or hiding archived entries via controller drawer switch
- pass archived visibility state through DeskSurface and NotebookTree
- persist archived preference in localStorage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689b6123596c832d844280858078b92f