### PR TITLE
feat: add themed card styles for tree

### DIFF
--- a/src/components/Tree/EntryCard.jsx
+++ b/src/components/Tree/EntryCard.jsx
@@ -3,7 +3,7 @@ import { Button } from 'antd';
 import { AnimatePresence, motion as Motion } from 'framer-motion';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import styles from './Tree.module.css';
+import styles from './EntryCard.module.css';
 
 const EntryCard = forwardRef(
   (
@@ -14,10 +14,13 @@ const EntryCard = forwardRef(
       id,
       disabled: disableDrag,
     });
+    const transformStyle = CSS.Transform.toString(transform);
     const style = {
-      transform: CSS.Transform.toString(transform),
+      transform:
+        transformStyle === 'none'
+          ? 'scale(var(--scale))'
+          : `${transformStyle} scale(var(--scale))`,
       transition,
-      marginBottom: '0.5rem',
     };
     const mergedRef = useCallback(
       (node) => {
@@ -82,7 +85,7 @@ const EntryCard = forwardRef(
   };
 
   return (
-    <div ref={mergedRef} style={style}>
+    <div ref={mergedRef} style={style} className={styles.card}>
       <div style={{ display: 'flex', alignItems: 'center' }}>
         {!disableDrag && (
           <span
@@ -95,7 +98,7 @@ const EntryCard = forwardRef(
           </span>
         )}
         <div
-          className={styles.entryTitle}
+          className={styles.title}
           style={{ cursor: actionsDisabled ? 'default' : 'pointer' }}
           onClick={onToggle}
         >
@@ -112,10 +115,10 @@ const EntryCard = forwardRef(
             style={{ overflow: 'hidden', marginLeft: '1rem' }}
             onClick={() => onEdit?.(entry)}
           >
-            {entry.snippet && <p className={styles.entrySnippet}>{entry.snippet}</p>}
+            {entry.snippet && <p className={styles.snippet}>{entry.snippet}</p>}
             {!actionsDisabled && (
               <div
-                className={styles.entryActions}
+                className={styles.actions}
                 onClick={(e) => e.stopPropagation()}
               >
                 <Button size="small" onClick={handleEdit}>

--- a/src/components/Tree/EntryCard.module.css
+++ b/src/components/Tree/EntryCard.module.css
@@ -1,0 +1,32 @@
+.card {
+  --scale: 1;
+  margin-bottom: 0.5rem;
+  padding: 1rem;
+  background-color: var(--ant-colorBgContainer);
+  color: var(--ant-colorText);
+  border: 1px solid var(--ant-colorBorder);
+  border-radius: 12px;
+  transition:
+    transform var(--ant-motion-duration-mid) ease,
+    background-color var(--ant-motion-duration-mid) ease;
+}
+
+.card:hover {
+  --scale: 1.02;
+  background-color: color-mix(in oklab, var(--ant-colorBgContainer) 90%, var(--ant-colorPrimary));
+}
+
+.title {
+  font-size: 1.5rem;
+}
+
+.snippet {
+  font-size: 1rem;
+  margin-top: 0.5rem;
+}
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}

--- a/src/components/Tree/GroupCard.jsx
+++ b/src/components/Tree/GroupCard.jsx
@@ -2,7 +2,7 @@ import React, { forwardRef, useCallback } from 'react';
 import { AnimatePresence, motion as Motion } from 'framer-motion';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import styles from './Tree.module.css';
+import styles from './GroupCard.module.css';
 
 const GroupCard = forwardRef(
   ({ id, title, isOpen, onToggle, children, disableDrag }, ref) => {
@@ -10,10 +10,13 @@ const GroupCard = forwardRef(
       id,
       disabled: disableDrag,
     });
+    const transformStyle = CSS.Transform.toString(transform);
     const style = {
-      transform: CSS.Transform.toString(transform),
+      transform:
+        transformStyle === 'none'
+          ? 'scale(var(--scale))'
+          : `${transformStyle} scale(var(--scale))`,
       transition,
-      marginBottom: '1rem',
     };
     const mergedRef = useCallback(
       (node) => {
@@ -25,7 +28,7 @@ const GroupCard = forwardRef(
     );
 
     return (
-      <div ref={mergedRef} style={style}>
+      <div ref={mergedRef} style={style} className={styles.card}>
         <div style={{ display: 'flex', alignItems: 'center' }}>
           {!disableDrag && (
             <span
@@ -38,7 +41,7 @@ const GroupCard = forwardRef(
             </span>
           )}
           <div
-            className={styles.groupTitle}
+            className={styles.title}
             style={{ cursor: 'pointer' }}
             onClick={onToggle}
           >

--- a/src/components/Tree/GroupCard.module.css
+++ b/src/components/Tree/GroupCard.module.css
@@ -1,0 +1,21 @@
+.card {
+  --scale: 1;
+  margin-bottom: 1rem;
+  padding: 1.5rem;
+  background-color: var(--ant-colorBgContainer);
+  color: var(--ant-colorText);
+  border: 1px solid var(--ant-colorBorder);
+  border-radius: 12px;
+  transition:
+    transform var(--ant-motion-duration-mid) ease,
+    background-color var(--ant-motion-duration-mid) ease;
+}
+
+.card:hover {
+  --scale: 1.02;
+  background-color: color-mix(in oklab, var(--ant-colorBgContainer) 90%, var(--ant-colorPrimary));
+}
+
+.title {
+  font-size: 2.5rem;
+}

--- a/src/components/Tree/SubgroupCard.jsx
+++ b/src/components/Tree/SubgroupCard.jsx
@@ -2,7 +2,7 @@ import React, { forwardRef, useCallback } from 'react';
 import { AnimatePresence, motion as Motion } from 'framer-motion';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import styles from './Tree.module.css';
+import styles from './SubgroupCard.module.css';
 
 const SubgroupCard = forwardRef(
   ({ id, title, isOpen, onToggle, children, disableDrag }, ref) => {
@@ -10,10 +10,13 @@ const SubgroupCard = forwardRef(
       id,
       disabled: disableDrag,
     });
+    const transformStyle = CSS.Transform.toString(transform);
     const style = {
-      transform: CSS.Transform.toString(transform),
+      transform:
+        transformStyle === 'none'
+          ? 'scale(var(--scale))'
+          : `${transformStyle} scale(var(--scale))`,
       transition,
-      marginBottom: '0.75rem',
     };
     const mergedRef = useCallback(
       (node) => {
@@ -25,7 +28,7 @@ const SubgroupCard = forwardRef(
     );
 
     return (
-      <div ref={mergedRef} style={style}>
+      <div ref={mergedRef} style={style} className={styles.card}>
         <div style={{ display: 'flex', alignItems: 'center' }}>
           {!disableDrag && (
             <span
@@ -38,7 +41,7 @@ const SubgroupCard = forwardRef(
             </span>
           )}
           <div
-            className={styles.subgroupTitle}
+            className={styles.title}
             style={{ cursor: 'pointer' }}
             onClick={onToggle}
           >

--- a/src/components/Tree/SubgroupCard.module.css
+++ b/src/components/Tree/SubgroupCard.module.css
@@ -1,0 +1,21 @@
+.card {
+  --scale: 1;
+  margin-bottom: 0.75rem;
+  padding: 1.25rem;
+  background-color: var(--ant-colorBgContainer);
+  color: var(--ant-colorText);
+  border: 1px solid var(--ant-colorBorder);
+  border-radius: 12px;
+  transition:
+    transform var(--ant-motion-duration-mid) ease,
+    background-color var(--ant-motion-duration-mid) ease;
+}
+
+.card:hover {
+  --scale: 1.02;
+  background-color: color-mix(in oklab, var(--ant-colorBgContainer) 90%, var(--ant-colorPrimary));
+}
+
+.title {
+  font-size: 2rem;
+}

--- a/src/components/Tree/Tree.module.css
+++ b/src/components/Tree/Tree.module.css
@@ -21,32 +21,9 @@
   font-family: 'IBM Plex Mono', 'Cutive Mono', monospace;
 }
 
-.groupTitle {
-  font-size: 3rem;
-}
-
-.subgroupTitle {
-  font-size: 2rem;
-}
-
-.entryTitle {
-  font-size: 1.5rem;
-}
-
 .nodeContainer {
   display: flex;
   flex-direction: column;
-}
-
-.entrySnippet {
-  font-size: 1rem;
-  margin-top: 0.5rem;
-}
-
-.entryActions {
-  display: flex;
-  gap: 0.5rem;
-  margin-top: 0.5rem;
 }
 
 /* Hover + selected states mapped to theme vars */


### PR DESCRIPTION
## Summary
- style tree group, subgroup, and entry cards with CSS modules
- apply theme-aware colors and hover scaling transitions
- clean up unused styles in tree module

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689b6e0d809c832da2b7601714108867