### PR TITLE
Implement FS entry editor drawer and context refresh

### DIFF
--- a/src/components/Desk/DeskSurface.jsx
+++ b/src/components/Desk/DeskSurface.jsx
@@ -334,7 +334,15 @@ export default function DeskSurface({
     });
   };
 
-  const handleCancel = () => {
+  const handleCancel = (skipRefresh = false) => {
+    if (
+      !skipRefresh &&
+      editorState.type === 'entry' &&
+      editorState.parent?.subgroupId &&
+      editorState.parent?.groupId
+    ) {
+      reloadEntries(editorState.parent.subgroupId, editorState.parent.groupId);
+    }
     setEditorState({ isOpen: false, type: null, parent: null, item: null, mode: 'create' });
     setDrawerPinned(false);
     setDrawerOpen(false);
@@ -479,7 +487,7 @@ export default function DeskSurface({
     } catch (err) {
       console.error('Delete failed', err);
     }
-    handleCancel();
+    handleCancel(true);
   };
 
   const handleArchive = async () => {
@@ -494,7 +502,7 @@ export default function DeskSurface({
     } catch (err) {
       console.error('Archive failed', err);
     }
-    handleCancel();
+    handleCancel(true);
   };
 
   const handleNotebookSave = async () => {
@@ -505,7 +513,7 @@ export default function DeskSurface({
 
   const handleNotebookSaveAndClose = async () => {
     await handleSave({ title, content, subgroupId: editorState.parent?.subgroupId });
-    handleCancel();
+    handleCancel(true);
   };
 
 
@@ -656,9 +664,9 @@ export default function DeskSurface({
       <FullScreenCanvas
         open={editorState.isOpen && editorState.type === 'entry'}
         onClose={handleCancel}
+        drawerProps={{ template: 'editor', ...editorDrawerProps }}
       >
         <NotebookEditor {...editorProps} />
-        <Drawer template="editor" {...editorDrawerProps} />
       </FullScreenCanvas>
 
       <AntDrawer

--- a/src/components/Editor/FullScreenCanvas.jsx
+++ b/src/components/Editor/FullScreenCanvas.jsx
@@ -1,5 +1,6 @@
 // src/components/Editor/FullScreenCanvas.jsx
 import React from 'react';
+import Drawer from '@/components/Drawer/Drawer';
 
 /**
  * Generic full screen overlay component used for editor modals.
@@ -11,6 +12,7 @@ export default function FullScreenCanvas({
   onClose,
   className = '',
   children,
+  drawerProps,
 }) {
   if (!open) return null;
 
@@ -25,6 +27,7 @@ export default function FullScreenCanvas({
   return (
     <div className={overlayClass} onClick={handleClick}>
       {children}
+      {drawerProps && <Drawer {...drawerProps} />}
     </div>
   );
 }

--- a/src/components/Tree/NotebookTree.jsx
+++ b/src/components/Tree/NotebookTree.jsx
@@ -412,15 +412,20 @@ export default function NotebookTree({
                                   !reorderMode ||
                                   openSubgroupId !== sub.key ||
                                   openEntryId !== null;
+                                const entryWithContext = {
+                                  ...entry,
+                                  subgroupId: sub.key,
+                                  groupId: group.key,
+                                };
                                 return (
                                   <EntryCard
                                     key={entry.key}
                                     id={entry.key}
                                     disableDrag={entryDragDisabled}
-                                    ref={(el) => (entryRefs.current[entry.id] = el)}
-                                    entry={entry}
+                                    ref={(el) => (entryRefs.current[entryWithContext.id] = el)}
+                                    entry={entryWithContext}
                                     isOpen={openEntryId === entry.id}
-                                    onToggle={() => handleEntryToggle(entry)}
+                                    onToggle={() => handleEntryToggle(entryWithContext)}
                                     onEdit={onEdit}
                                     actionsDisabled={manageMode}
                                   />


### PR DESCRIPTION
## Summary
- pass group/subgroup context from entry cards to editor launcher
- add drawer support to FullScreenCanvas for full-screen editor menu
- refresh tree and delay root drawer when closing editor

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689b784079a0832d915b7c81a9fb37b1