### PR TITLE
fix: prevent duplicate entries when saving

### DIFF
--- a/src/components/Drawer/templates.jsx
+++ b/src/components/Drawer/templates.jsx
@@ -35,6 +35,7 @@ export function editor({
   onDelete,
   onArchive,
   onCancel,
+  saving = false,
 }) {
   const subgroupOptions = groups.flatMap((g) =>
     g.subgroups.map((s) => ({ value: s.id, label: `${g.name} / ${s.name}` }))
@@ -73,10 +74,18 @@ export function editor({
           size="small"
         />
       )}
-      <Button className="drawer-btn drawer-btn-save" onClick={onSave}>
+      <Button
+        className="drawer-btn drawer-btn-save"
+        onClick={onSave}
+        disabled={saving}
+      >
         Save
       </Button>
-      <Button className="drawer-btn drawer-btn-save" onClick={onSaveAndClose}>
+      <Button
+        className="drawer-btn drawer-btn-save"
+        onClick={onSaveAndClose}
+        disabled={saving}
+      >
         Save and Close
       </Button>
       {mode === 'edit' && onDelete && (


### PR DESCRIPTION
## Summary
- track saving state and capture new entry IDs to switch editor to edit mode
- disable drawer save buttons while saving to avoid duplicate submissions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689b7f53a40c832d863f72a88d38401c