### PR TITLE
Add full focus mode toggle across drawers

### DIFF
--- a/src/components/Desk/DeskSurface.jsx
+++ b/src/components/Desk/DeskSurface.jsx
@@ -95,6 +95,18 @@ export default function DeskSurface({
   const [controllerPinned, setControllerPinned] = useState(false);
   const controllerCloseTimeoutRef = useRef(null);
 
+  const [fullFocus, setFullFocus] = useState(false);
+
+  useEffect(() => {
+    const handleFullscreenChange = () => {
+      setFullFocus(!!document.fullscreenElement);
+    };
+    document.addEventListener('fullscreenchange', handleFullscreenChange);
+    return () => {
+      document.removeEventListener('fullscreenchange', handleFullscreenChange);
+    };
+  }, []);
+
   const throttleManageHover = () => {
     setManageHoverDisabled(true);
     if (manageHoverTimeoutRef.current) {
@@ -439,6 +451,15 @@ export default function DeskSurface({
     window.dispatchEvent(new Event('pomodoro-start'));
   }, [pomodoroEnabled]);
 
+  const toggleFullFocus = () => {
+    if (fullFocus) {
+      document.exitFullscreen?.();
+    } else {
+      document.documentElement.requestFullscreen?.();
+    }
+    setFullFocus((prev) => !prev);
+  };
+
   const handleControllerHamburgerClick = () => {
     if (showEdits) return;
     setControllerPinned((prev) => {
@@ -627,6 +648,8 @@ export default function DeskSurface({
     onMouseLeave: handleDrawerMouseLeave,
     pomodoroEnabled,
     onPomodoroToggle: handlePomodoroToggle,
+    fullFocus,
+    onFullFocusToggle: toggleFullFocus,
     maxWidth,
     onMaxWidthChange: handleMaxWidthChange,
     type: editorState.type,
@@ -654,6 +677,8 @@ export default function DeskSurface({
     onToggleEdits: () => setShowEdits((prev) => !prev),
     reorderMode,
     onToggleReorder: () => setReorderMode((prev) => !prev),
+    fullFocus,
+    onFullFocusToggle: toggleFullFocus,
     showArchived,
     onToggleArchived: handleToggleArchived,
     onAddNotebookDrawerChange: (open) => {

--- a/src/components/Drawer/templates.jsx
+++ b/src/components/Drawer/templates.jsx
@@ -22,6 +22,8 @@ import { ThemeContext } from '../ThemeProvider';
 export function editor({
   pomodoroEnabled,
   onPomodoroToggle,
+  fullFocus,
+  onFullFocusToggle,
   maxWidth,
   onMaxWidthChange,
   type,
@@ -52,6 +54,10 @@ export function editor({
       <div style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
         <span>Pomodoro</span>
         <Switch checked={pomodoroEnabled} onChange={onPomodoroToggle} size="small" />
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
+        <span>Full Focus Mode</span>
+        <Switch checked={fullFocus} onChange={onFullFocusToggle} size="small" />
       </div>
       <div style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
         <span>Max Width</span>
@@ -113,6 +119,8 @@ function NotebookControllerContent({
   onToggleEdits,
   reorderMode,
   onToggleReorder,
+  fullFocus,
+  onFullFocusToggle,
   showArchived,
   onToggleArchived,
   onAddNotebookDrawerChange,
@@ -246,6 +254,10 @@ function NotebookControllerContent({
         <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
           <Switch checked={reorderMode} onChange={onToggleReorder} />
           <span>Re-order</span>
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+          <Switch checked={fullFocus} onChange={onFullFocusToggle} />
+          <span>Full Focus Mode</span>
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
           <Switch


### PR DESCRIPTION
## Summary
- track fullscreen state in DeskSurface and expose toggle to drawers
- add "Full Focus Mode" switches to editor and controller drawer templates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689b8538bcf0832dbffc568d7916775d