### PR TITLE
style: soften card borders and add depth

### DIFF
--- a/src/components/Tree/EntryCard.module.css
+++ b/src/components/Tree/EntryCard.module.css
@@ -2,13 +2,19 @@
   --scale: 1;
   margin-bottom: 0.5rem;
   padding: 1rem;
-  background-color: var(--ant-colorBgContainer);
+  background-color: color-mix(in srgb, var(--ant-colorBgContainer) 88%, var(--ant-colorText) 12%);
   color: var(--ant-colorText);
-  border: 1px solid var(--ant-colorBorder);
-  border-radius: 12px;
+  border: 0;
+  border-radius: 1rem;
+  user-select: none;
+  box-shadow: 0 2px 4px color-mix(in srgb, var(--ant-colorText) 25%, transparent);
   transition:
     transform var(--ant-motion-duration-mid) ease,
     background-color var(--ant-motion-duration-mid) ease;
+}
+
+body[data-theme="dark"] .card {
+  background-color: color-mix(in srgb, var(--ant-colorBgContainer) 88%, var(--ant-colorText) 12%);
 }
 
 .card:hover {

--- a/src/components/Tree/GroupCard.module.css
+++ b/src/components/Tree/GroupCard.module.css
@@ -2,13 +2,19 @@
   --scale: 1;
   margin-bottom: 1rem;
   padding: 1.5rem;
-  background-color: var(--ant-colorBgContainer);
+  background-color: color-mix(in srgb, var(--ant-colorBgContainer) 96%, var(--ant-colorText) 4%);
   color: var(--ant-colorText);
-  border: 1px solid var(--ant-colorBorder);
-  border-radius: 12px;
+  border: 0;
+  border-radius: 1rem;
+  user-select: none;
+  box-shadow: 0 2px 4px color-mix(in srgb, var(--ant-colorText) 25%, transparent);
   transition:
     transform var(--ant-motion-duration-mid) ease,
     background-color var(--ant-motion-duration-mid) ease;
+}
+
+body[data-theme="dark"] .card {
+  background-color: color-mix(in srgb, var(--ant-colorBgContainer) 96%, var(--ant-colorText) 4%);
 }
 
 .card:hover {

--- a/src/components/Tree/SubgroupCard.module.css
+++ b/src/components/Tree/SubgroupCard.module.css
@@ -2,13 +2,19 @@
   --scale: 1;
   margin-bottom: 0.75rem;
   padding: 1.25rem;
-  background-color: var(--ant-colorBgContainer);
+  background-color: color-mix(in srgb, var(--ant-colorBgContainer) 92%, var(--ant-colorText) 8%);
   color: var(--ant-colorText);
-  border: 1px solid var(--ant-colorBorder);
-  border-radius: 12px;
+  border: 0;
+  border-radius: 1rem;
+  user-select: none;
+  box-shadow: 0 2px 4px color-mix(in srgb, var(--ant-colorText) 25%, transparent);
   transition:
     transform var(--ant-motion-duration-mid) ease,
     background-color var(--ant-motion-duration-mid) ease;
+}
+
+body[data-theme="dark"] .card {
+  background-color: color-mix(in srgb, var(--ant-colorBgContainer) 92%, var(--ant-colorText) 8%);
 }
 
 .card:hover {


### PR DESCRIPTION
## Summary
- remove card borders, round corners, and add selection safety
- elevate group, subgroup, and entry cards with subtle shadows and depth‑tinted backgrounds

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689bc7374178832db7bc5754c611d2d1