### PR TITLE
feat: support manage mode for tree cards

### DIFF
--- a/src/components/Tree/EntryCard.jsx
+++ b/src/components/Tree/EntryCard.jsx
@@ -1,4 +1,5 @@
 import React, { forwardRef, useCallback } from 'react';
+import classNames from 'classnames';
 import { Button } from 'antd';
 import { AnimatePresence, motion as Motion } from 'framer-motion';
 import { useSortable } from '@dnd-kit/sortable';
@@ -7,7 +8,16 @@ import styles from './EntryCard.module.css';
 
 const EntryCard = forwardRef(
   (
-    { id, entry, isOpen, onToggle, onEdit, disableDrag, actionsDisabled },
+    {
+      id,
+      entry,
+      isOpen,
+      onToggle,
+      onEdit,
+      disableDrag,
+      actionsDisabled,
+      manageMode,
+    },
     ref
   ) => {
     const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
@@ -85,7 +95,11 @@ const EntryCard = forwardRef(
   };
 
   return (
-    <div ref={mergedRef} style={style} className={styles.card}>
+    <div
+      ref={mergedRef}
+      style={style}
+      className={classNames(styles.card, { [styles.interactive]: !manageMode })}
+    >
       <div style={{ display: 'flex', alignItems: 'center' }}>
         {!disableDrag && (
           <span
@@ -112,7 +126,7 @@ const EntryCard = forwardRef(
             animate={{ height: 'auto', opacity: 1 }}
             exit={{ height: 0, opacity: 0 }}
             transition={{ duration: 0.2 }}
-            style={{ overflow: 'hidden', marginLeft: '1rem' }}
+            style={{ overflow: 'visible', marginLeft: '1rem', padding: '0.25rem 0' }}
             onClick={() => onEdit?.(entry)}
           >
             {entry.snippet && <p className={styles.snippet}>{entry.snippet}</p>}

--- a/src/components/Tree/EntryCard.module.css
+++ b/src/components/Tree/EntryCard.module.css
@@ -17,9 +17,14 @@ body[data-theme="dark"] .card {
   background-color: color-mix(in srgb, var(--ant-colorBgContainer) 88%, var(--ant-colorText) 12%);
 }
 
+.interactive {}
+
 .card:hover {
-  --scale: 1.02;
   background-color: color-mix(in oklab, var(--ant-colorBgContainer) 90%, var(--ant-colorPrimary));
+}
+
+.card.interactive:hover {
+  --scale: 1.02;
 }
 
 .title {

--- a/src/components/Tree/GroupCard.jsx
+++ b/src/components/Tree/GroupCard.jsx
@@ -1,11 +1,15 @@
 import React, { forwardRef, useCallback } from 'react';
+import classNames from 'classnames';
 import { AnimatePresence, motion as Motion } from 'framer-motion';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import styles from './GroupCard.module.css';
 
 const GroupCard = forwardRef(
-  ({ id, title, isOpen, onToggle, children, disableDrag }, ref) => {
+  (
+    { id, title, isOpen, onToggle, children, disableDrag, manageMode },
+    ref
+  ) => {
     const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
       id,
       disabled: disableDrag,
@@ -28,7 +32,11 @@ const GroupCard = forwardRef(
     );
 
     return (
-      <div ref={mergedRef} style={style} className={styles.card}>
+      <div
+        ref={mergedRef}
+        style={style}
+        className={classNames(styles.card, { [styles.interactive]: !manageMode })}
+      >
         <div style={{ display: 'flex', alignItems: 'center' }}>
           {!disableDrag && (
             <span
@@ -55,7 +63,7 @@ const GroupCard = forwardRef(
               animate={{ height: 'auto', opacity: 1 }}
               exit={{ height: 0, opacity: 0 }}
               transition={{ duration: 0.2 }}
-              style={{ overflow: 'hidden', marginLeft: '1rem' }}
+              style={{ overflow: 'visible', marginLeft: '1rem', padding: '0.25rem 0' }}
             >
               {children}
             </Motion.div>

--- a/src/components/Tree/GroupCard.module.css
+++ b/src/components/Tree/GroupCard.module.css
@@ -17,9 +17,14 @@ body[data-theme="dark"] .card {
   background-color: color-mix(in srgb, var(--ant-colorBgContainer) 96%, var(--ant-colorText) 4%);
 }
 
+.interactive {}
+
 .card:hover {
-  --scale: 1.02;
   background-color: color-mix(in oklab, var(--ant-colorBgContainer) 90%, var(--ant-colorPrimary));
+}
+
+.card.interactive:hover {
+  --scale: 1.02;
 }
 
 .title {

--- a/src/components/Tree/NotebookTree.jsx
+++ b/src/components/Tree/NotebookTree.jsx
@@ -373,6 +373,7 @@ export default function NotebookTree({
                 title={group.title}
                 isOpen={manageMode || openGroupId === group.key}
                 onToggle={() => handleGroupToggle(group)}
+                manageMode={manageMode}
               >
                 <DndContext
                   collisionDetection={closestCenter}
@@ -397,6 +398,7 @@ export default function NotebookTree({
                           title={sub.title}
                           isOpen={manageMode || openSubgroupId === sub.key}
                           onToggle={() => handleSubgroupToggle(sub)}
+                          manageMode={manageMode}
                         >
                           <DndContext
                             collisionDetection={closestCenter}
@@ -428,6 +430,7 @@ export default function NotebookTree({
                                     onToggle={() => handleEntryToggle(entryWithContext)}
                                     onEdit={onEdit}
                                     actionsDisabled={manageMode}
+                                    manageMode={manageMode}
                                   />
                                 );
                               })}

--- a/src/components/Tree/SubgroupCard.jsx
+++ b/src/components/Tree/SubgroupCard.jsx
@@ -1,11 +1,15 @@
 import React, { forwardRef, useCallback } from 'react';
+import classNames from 'classnames';
 import { AnimatePresence, motion as Motion } from 'framer-motion';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import styles from './SubgroupCard.module.css';
 
 const SubgroupCard = forwardRef(
-  ({ id, title, isOpen, onToggle, children, disableDrag }, ref) => {
+  (
+    { id, title, isOpen, onToggle, children, disableDrag, manageMode },
+    ref
+  ) => {
     const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
       id,
       disabled: disableDrag,
@@ -28,7 +32,11 @@ const SubgroupCard = forwardRef(
     );
 
     return (
-      <div ref={mergedRef} style={style} className={styles.card}>
+      <div
+        ref={mergedRef}
+        style={style}
+        className={classNames(styles.card, { [styles.interactive]: !manageMode })}
+      >
         <div style={{ display: 'flex', alignItems: 'center' }}>
           {!disableDrag && (
             <span
@@ -55,7 +63,7 @@ const SubgroupCard = forwardRef(
               animate={{ height: 'auto', opacity: 1 }}
               exit={{ height: 0, opacity: 0 }}
               transition={{ duration: 0.2 }}
-              style={{ overflow: 'hidden', marginLeft: '1rem' }}
+              style={{ overflow: 'visible', marginLeft: '1rem', padding: '0.25rem 0' }}
             >
               {children}
             </Motion.div>

--- a/src/components/Tree/SubgroupCard.module.css
+++ b/src/components/Tree/SubgroupCard.module.css
@@ -17,9 +17,14 @@ body[data-theme="dark"] .card {
   background-color: color-mix(in srgb, var(--ant-colorBgContainer) 92%, var(--ant-colorText) 8%);
 }
 
+.interactive {}
+
 .card:hover {
-  --scale: 1.02;
   background-color: color-mix(in oklab, var(--ant-colorBgContainer) 90%, var(--ant-colorPrimary));
+}
+
+.card.interactive:hover {
+  --scale: 1.02;
 }
 
 .title {


### PR DESCRIPTION
## Summary
- add `manageMode` to GroupCard, SubgroupCard, and EntryCard
- limit hover scaling to interactive cards and add spacing to Motion wrappers
- pass manage state through NotebookTree

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689bd2cce914832d948822c203833a4e