### PR TITLE
Use HolderOutlined icon for drag handles

### DIFF
--- a/src/components/Tree/EntryCard.jsx
+++ b/src/components/Tree/EntryCard.jsx
@@ -4,6 +4,7 @@ import { Button } from 'antd';
 import { AnimatePresence, motion as Motion } from 'framer-motion';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
+import { HolderOutlined } from '@ant-design/icons';
 import styles from './EntryCard.module.css';
 
 const EntryCard = forwardRef(
@@ -108,7 +109,7 @@ const EntryCard = forwardRef(
             onClick={(e) => e.stopPropagation()}
             style={{ cursor: 'grab', marginRight: '0.5rem' }}
           >
-            =
+            <HolderOutlined />
           </span>
         )}
         <div

--- a/src/components/Tree/GroupCard.jsx
+++ b/src/components/Tree/GroupCard.jsx
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import { AnimatePresence, motion as Motion } from 'framer-motion';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
+import { HolderOutlined } from '@ant-design/icons';
 import styles from './GroupCard.module.css';
 
 const GroupCard = forwardRef(
@@ -45,7 +46,7 @@ const GroupCard = forwardRef(
               onClick={(e) => e.stopPropagation()}
               style={{ cursor: 'grab', marginRight: '0.5rem' }}
             >
-              =
+              <HolderOutlined />
             </span>
           )}
           <div

--- a/src/components/Tree/NotebookTree.test.jsx
+++ b/src/components/Tree/NotebookTree.test.jsx
@@ -47,12 +47,12 @@ describe('NotebookTree custom cards', () => {
       { title: 'Group 2', key: 'g2', children: [] },
     ];
     const { rerender } = render(<NotebookTree treeData={treeData} />);
-    expect(screen.queryAllByText('=').length).toBe(0);
+    expect(screen.queryAllByRole('img', { name: 'holder' }).length).toBe(0);
     rerender(<NotebookTree treeData={treeData} reorderMode />);
-    expect(screen.getAllByText('=').length).toBe(2);
+    expect(screen.getAllByRole('img', { name: 'holder' }).length).toBe(2);
     await user.click(screen.getByText('Group 1'));
     await screen.findByText('Sub 1');
-    expect(screen.getAllByText('=').length).toBe(1);
+    expect(screen.getAllByRole('img', { name: 'holder' }).length).toBe(1);
   });
 
   it('loads existing values into entity edit drawer', async () => {

--- a/src/components/Tree/SubgroupCard.jsx
+++ b/src/components/Tree/SubgroupCard.jsx
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import { AnimatePresence, motion as Motion } from 'framer-motion';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
+import { HolderOutlined } from '@ant-design/icons';
 import styles from './SubgroupCard.module.css';
 
 const SubgroupCard = forwardRef(
@@ -45,7 +46,7 @@ const SubgroupCard = forwardRef(
               onClick={(e) => e.stopPropagation()}
               style={{ cursor: 'grab', marginRight: '0.5rem' }}
             >
-              =
+              <HolderOutlined />
             </span>
           )}
           <div


### PR DESCRIPTION
## Summary
- swap text drag handle with `HolderOutlined` icon for group, subgroup and entry cards
- update tree tests to check for `HolderOutlined` icon

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689bd5335ed4832d978437d8bf09a2db