### PR TITLE
fix: add fallbacks for card background and shadow

### DIFF
--- a/src/components/Tree/EntryCard.module.css
+++ b/src/components/Tree/EntryCard.module.css
@@ -2,11 +2,14 @@
   --scale: 1;
   margin-bottom: 0.5rem;
   padding: 1rem;
+  /* Fallbacks for browsers without color-mix support */
+  background-color: var(--ant-colorBgContainer);
   background-color: color-mix(in srgb, var(--ant-colorBgContainer) 88%, var(--ant-colorText) 12%);
   color: var(--ant-colorText);
   border: 0;
   border-radius: 1rem;
   user-select: none;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   box-shadow: 0 2px 4px color-mix(in srgb, var(--ant-colorText) 25%, transparent);
   transition:
     transform var(--ant-motion-duration-mid) ease,
@@ -14,7 +17,10 @@
 }
 
 body[data-theme="dark"] .card {
+  background-color: var(--ant-colorBgContainer);
   background-color: color-mix(in srgb, var(--ant-colorBgContainer) 88%, var(--ant-colorText) 12%);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 2px 4px color-mix(in srgb, var(--ant-colorText) 25%, transparent);
 }
 
 .interactive {}

--- a/src/components/Tree/GroupCard.module.css
+++ b/src/components/Tree/GroupCard.module.css
@@ -2,11 +2,14 @@
   --scale: 1;
   margin-bottom: 1rem;
   padding: 1.5rem;
+  /* Fallbacks for browsers without color-mix support */
+  background-color: var(--ant-colorBgContainer);
   background-color: color-mix(in srgb, var(--ant-colorBgContainer) 96%, var(--ant-colorText) 4%);
   color: var(--ant-colorText);
   border: 0;
   border-radius: 1rem;
   user-select: none;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   box-shadow: 0 2px 4px color-mix(in srgb, var(--ant-colorText) 25%, transparent);
   transition:
     transform var(--ant-motion-duration-mid) ease,
@@ -14,7 +17,10 @@
 }
 
 body[data-theme="dark"] .card {
+  background-color: var(--ant-colorBgContainer);
   background-color: color-mix(in srgb, var(--ant-colorBgContainer) 96%, var(--ant-colorText) 4%);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 2px 4px color-mix(in srgb, var(--ant-colorText) 25%, transparent);
 }
 
 .interactive {}

--- a/src/components/Tree/SubgroupCard.module.css
+++ b/src/components/Tree/SubgroupCard.module.css
@@ -2,11 +2,14 @@
   --scale: 1;
   margin-bottom: 0.75rem;
   padding: 1.25rem;
+  /* Fallbacks for browsers without color-mix support */
+  background-color: var(--ant-colorBgContainer);
   background-color: color-mix(in srgb, var(--ant-colorBgContainer) 92%, var(--ant-colorText) 8%);
   color: var(--ant-colorText);
   border: 0;
   border-radius: 1rem;
   user-select: none;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   box-shadow: 0 2px 4px color-mix(in srgb, var(--ant-colorText) 25%, transparent);
   transition:
     transform var(--ant-motion-duration-mid) ease,
@@ -14,7 +17,10 @@
 }
 
 body[data-theme="dark"] .card {
+  background-color: var(--ant-colorBgContainer);
   background-color: color-mix(in srgb, var(--ant-colorBgContainer) 92%, var(--ant-colorText) 8%);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 2px 4px color-mix(in srgb, var(--ant-colorText) 25%, transparent);
 }
 
 .interactive {}


### PR DESCRIPTION
## Summary
- ensure Group, Subgroup, and Entry cards render background colors and elevation
- add light/dark theme fallbacks for card backgrounds and shadows

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689b837fa6cc832d8c8f9e37a9eb1cb5