### PR TITLE
feat: add Windows 95 style form controls

### DIFF
--- a/src/components/Editor/NotebookEditor.jsx
+++ b/src/components/Editor/NotebookEditor.jsx
@@ -73,11 +73,11 @@ export default function NotebookEditor({
           <div className="entry-title-row" style={{ maxWidth: `${maxWidth}%` }}>
             <div className="entry-title-container">
               {isEditingTitle ? (
-                <input
-                  type="text"
-                  className="entry-title-input"
-                  value={titleInput}
-                  onChange={(e) => setTitleInput(e.target.value)}
+                  <input
+                    type="text"
+                    className="entry-title-input indie-input"
+                    value={titleInput}
+                    onChange={(e) => setTitleInput(e.target.value)}
                   onBlur={() => {
                     setTitle(titleInput);
                     setIsEditingTitle(false);

--- a/src/components/LandingPage.jsx
+++ b/src/components/LandingPage.jsx
@@ -33,64 +33,52 @@ export default function LandingPage() {
           </ul>
         </nav>
       </header>
-      <main className="hero" style={{ textAlign: 'center', padding: '4rem 2rem' }}>
-        <h1 style={{ fontSize: '3rem', marginBottom: '1rem' }}>Welcome to InMyWords</h1>
-        <p style={{ fontSize: '1.25rem', marginBottom: '2rem' }}>
-          A sensory-friendly space to capture your thoughts and ideas.
-        </p>
-        <button
-          style={{
-            padding: '0.75rem 1.5rem',
-            fontSize: '1rem',
-            cursor: 'pointer',
-            border: 'none',
-            borderRadius: '4px',
-            backgroundColor: '#0070f3',
-            color: '#fff',
-          }}
-        >
-          Get Started
-        </button>
-      </main>
+        <main className="hero" style={{ textAlign: 'center', padding: '4rem 2rem' }}>
+          <h1 style={{ fontSize: '3rem', marginBottom: '1rem' }}>Welcome to InMyWords</h1>
+          <p style={{ fontSize: '1.25rem', marginBottom: '2rem' }}>
+            A sensory-friendly space to capture your thoughts and ideas.
+          </p>
+          <button className="indie-button">Get Started</button>
+        </main>
       <div className="login-container">
         <h2>Login</h2>
-        <div>
-          <input
-            type="text"
-            placeholder="Email or Username"
-            value={identifier}
-            onChange={e => setIdentifier(e.target.value)}
-            style={{ width: '100%', marginBottom: '0.5rem' }}
-          />
-        </div>
-        <div>
-          <input
-            type="password"
-            placeholder="Password"
-            value={password}
-            onChange={e => setPassword(e.target.value)}
-            style={{ width: '100%', marginBottom: '1rem' }}
-          />
-        </div>
-        <div style={{ marginBottom: '1rem' }}>
-          <Checkbox>
-            I agree to the <a href="/terms" target="_blank" rel="noopener noreferrer">Terms of Service</a> and <a href="/privacy" target="_blank" rel="noopener noreferrer">Privacy Policy</a>
-          </Checkbox>
-        </div>
-        <div>
-          <button onClick={handleLogin} style={{ marginRight: '0.5rem' }}>
-            Login
-          </button>
-          <button onClick={() => alert('Account creation is disabled')}>
-            Create an account
-          </button>
-        </div>
-        <div style={{ marginTop: '0.5rem' }}>
-          <button onClick={() => signIn('google')} style={{ width: '100%' }}>
-            Sign in with Google
-          </button>
-        </div>
-        {error && <p style={{ color: 'red' }}>{error}</p>}
+          <div>
+            <input
+              type="text"
+              placeholder="Email or Username"
+              value={identifier}
+              onChange={e => setIdentifier(e.target.value)}
+              className="indie-input"
+            />
+          </div>
+          <div>
+            <input
+              type="password"
+              placeholder="Password"
+              value={password}
+              onChange={e => setPassword(e.target.value)}
+              className="indie-input"
+            />
+          </div>
+          <div className="terms-row">
+            <Checkbox>
+              I agree to the <a href="/terms" target="_blank" rel="noopener noreferrer">Terms of Service</a> and <a href="/privacy" target="_blank" rel="noopener noreferrer">Privacy Policy</a>
+            </Checkbox>
+          </div>
+          <div className="button-row">
+            <button onClick={handleLogin} className="indie-button">
+              Login
+            </button>
+            <button onClick={() => alert('Account creation is disabled')} className="indie-button">
+              Create an account
+            </button>
+          </div>
+          <div className="google-button">
+            <button onClick={() => signIn('google')} className="indie-button">
+              Sign in with Google
+            </button>
+          </div>
+          {error && <p className="login-error">{error}</p>}
       </div>
     </div>
   );

--- a/src/components/PomodoroWidget.jsx
+++ b/src/components/PomodoroWidget.jsx
@@ -213,31 +213,34 @@ export default function PomodoroWidget() {
           <div style={{ marginBottom: '0.25rem' }}>{label}</div>
           <label style={{ display: 'block' }}>
             Pomodoro:
-            <input
-              type="number"
-              value={Math.floor(durations.pomodoro / 60)}
-              onChange={(e) => updateDuration('pomodoro', e.target.value)}
-              style={{ width: '3rem', marginLeft: '0.25rem' }}
-            />
-          </label>
-          <label style={{ display: 'block' }}>
-            Short:
-            <input
-              type="number"
-              value={Math.floor(durations.shortBreak / 60)}
-              onChange={(e) => updateDuration('shortBreak', e.target.value)}
-              style={{ width: '3rem', marginLeft: '0.25rem' }}
-            />
-          </label>
-          <label style={{ display: 'block' }}>
-            Long:
-            <input
-              type="number"
-              value={Math.floor(durations.longBreak / 60)}
-              onChange={(e) => updateDuration('longBreak', e.target.value)}
-              style={{ width: '3rem', marginLeft: '0.25rem' }}
-            />
-          </label>
+              <input
+                type="number"
+                value={Math.floor(durations.pomodoro / 60)}
+                onChange={(e) => updateDuration('pomodoro', e.target.value)}
+                style={{ width: '3rem', marginLeft: '0.25rem' }}
+                className="indie-input"
+              />
+            </label>
+            <label style={{ display: 'block' }}>
+              Short:
+              <input
+                type="number"
+                value={Math.floor(durations.shortBreak / 60)}
+                onChange={(e) => updateDuration('shortBreak', e.target.value)}
+                style={{ width: '3rem', marginLeft: '0.25rem' }}
+                className="indie-input"
+              />
+            </label>
+            <label style={{ display: 'block' }}>
+              Long:
+              <input
+                type="number"
+                value={Math.floor(durations.longBreak / 60)}
+                onChange={(e) => updateDuration('longBreak', e.target.value)}
+                style={{ width: '3rem', marginLeft: '0.25rem' }}
+                className="indie-input"
+              />
+            </label>
         </div>
       )}
     </div>

--- a/src/components/ThemeProvider.jsx
+++ b/src/components/ThemeProvider.jsx
@@ -44,6 +44,25 @@ export default function ThemeProvider({ children }) {
     if (typeof window === 'undefined') return;
     localStorage.setItem('theme', darkMode ? 'dark' : 'light');
     document.body.setAttribute('data-theme', darkMode ? 'dark' : 'light');
+
+    // Expose Windows-95 style variables for inputs/buttons
+    const root = document.documentElement;
+    const lightVars = {
+      '--indie-bg': '#c0c0c0',
+      '--indie-border-light': '#ffffff',
+      '--indie-border-dark': '#808080',
+      '--indie-text': '#000000',
+    };
+    const darkVars = {
+      '--indie-bg': '#3a3a3a',
+      '--indie-border-light': '#999999',
+      '--indie-border-dark': '#000000',
+      '--indie-text': '#ffffff',
+    };
+    const vars = darkMode ? darkVars : lightVars;
+    Object.entries(vars).forEach(([key, value]) => {
+      root.style.setProperty(key, value);
+    });
   }, [darkMode]);
 
   const toggleTheme = () => {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -10,6 +10,44 @@ body {
   transition: background-color 0.3s ease, color 0.3s ease;
 }
 
+/* Windows-95 inspired form controls */
+.indie-input,
+.indie-button {
+  font-family: inherit;
+  padding: 0.25rem 0.5rem;
+  border-width: 2px;
+  border-style: solid;
+  background: var(--indie-bg);
+  color: var(--indie-text);
+}
+
+/* Light theme bevel */
+body[data-theme='light'] .indie-input,
+body[data-theme='light'] .indie-button {
+  border-top-color: var(--indie-border-light);
+  border-left-color: var(--indie-border-light);
+  border-bottom-color: var(--indie-border-dark);
+  border-right-color: var(--indie-border-dark);
+}
+
+/* Dark theme bevel */
+body[data-theme='dark'] .indie-input,
+body[data-theme='dark'] .indie-button {
+  border-top-color: var(--indie-border-light);
+  border-left-color: var(--indie-border-light);
+  border-bottom-color: var(--indie-border-dark);
+  border-right-color: var(--indie-border-dark);
+}
+
+/* Pressed button effect */
+body[data-theme='light'] .indie-button:active,
+body[data-theme='dark'] .indie-button:active {
+  border-top-color: var(--indie-border-dark);
+  border-left-color: var(--indie-border-dark);
+  border-bottom-color: var(--indie-border-light);
+  border-right-color: var(--indie-border-light);
+}
+
 /* Hide scrollbars globally for a consistent experience */
 * {
   -ms-overflow-style: none;
@@ -68,6 +106,42 @@ body[data-theme='dark'] .ant-drawer-close {
   padding: 1rem;
   border: 1px solid #ddd;
   border-radius: 4px;
+}
+
+.login-container .indie-input {
+  width: 100%;
+  margin-bottom: 0.5rem;
+}
+
+.login-container .button-row {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.login-container .button-row .indie-button {
+  flex: 1;
+}
+
+.login-container .google-button {
+  margin-top: 0.5rem;
+}
+
+.login-container .google-button .indie-button {
+  width: 100%;
+}
+
+.login-error {
+  color: red;
+}
+
+.login-container .terms-row {
+  margin-bottom: 1rem;
+}
+
+.hero .indie-button {
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
 }
 
 .navbar a {


### PR DESCRIPTION
## Summary
- add `indie-input` and `indie-button` classes with Windows 95 bevel styling
- expose indie control color variables in ThemeProvider
- apply new classes across LandingPage, NotebookEditor and Pomodoro widget

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689cbc15cf84832dab72a6c48e8ec3c6