### PR TITLE
feat: add highlight color picker

### DIFF
--- a/src/components/Drawer/templates.jsx
+++ b/src/components/Drawer/templates.jsx
@@ -13,6 +13,7 @@ import { signOut } from 'next-auth/react';
 import { EditOutlined, UserOutlined } from '@ant-design/icons';
 import Link from 'next/link';
 import { ThemeContext } from '../ThemeProvider';
+import HighlightColorPicker from '../HighlightColorPicker';
 
 /**
  * Template factory functions for Drawer.
@@ -278,6 +279,10 @@ function NotebookControllerContent({
         <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
           <span>Dark Mode</span>
           <Switch checked={darkMode} onChange={toggleTheme} />
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+          <span>Highlight</span>
+          <HighlightColorPicker />
         </div>
         <Button onClick={() => signOut({ redirect: false })}>Logout</Button>
       </div>

--- a/src/components/HighlightColorPicker.jsx
+++ b/src/components/HighlightColorPicker.jsx
@@ -1,0 +1,41 @@
+import React, { useContext } from 'react';
+import { ThemeContext } from './ThemeProvider';
+
+const SWATCHES = {
+  blue: '#1677ff',
+  green: '#52c41a',
+  red: '#ff4d4f',
+  yellow: '#faad14',
+  purple: '#722ed1',
+};
+
+export default function HighlightColorPicker() {
+  const { highlightColor, setHighlightColor } = useContext(ThemeContext);
+
+  const handleSelect = (color) => {
+    setHighlightColor(color);
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('highlightColor', color);
+    }
+  };
+
+  return (
+    <div style={{ display: 'flex', gap: '0.5rem' }}>
+      {Object.entries(SWATCHES).map(([name, color]) => (
+        <button
+          key={name}
+          onClick={() => handleSelect(name)}
+          aria-label={`select ${name}`}
+          style={{
+            width: '1.25rem',
+            height: '1.25rem',
+            borderRadius: '50%',
+            border: highlightColor === name ? '2px solid var(--highlight-color)' : '2px solid transparent',
+            backgroundColor: color,
+            cursor: 'pointer',
+          }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/ThemeProvider.jsx
+++ b/src/components/ThemeProvider.jsx
@@ -2,20 +2,31 @@
 import React, { createContext, useEffect, useState } from 'react';
 import { ConfigProvider } from 'antd';
 
+const HIGHLIGHT_COLORS = {
+  blue: { light: '#1677ff', dark: '#69b1ff' },
+  green: { light: '#52c41a', dark: '#95de64' },
+  red: { light: '#ff4d4f', dark: '#ff7875' },
+  yellow: { light: '#faad14', dark: '#ffd666' },
+  purple: { light: '#722ed1', dark: '#b37feb' },
+};
+
 export const ThemeContext = createContext({
   darkMode: false,
-  toggleTheme: () => { },
+  toggleTheme: () => {},
+  highlightColor: 'green',
+  setHighlightColor: () => {},
 });
 
 export default function ThemeProvider({ children }) {
   const [darkMode, setDarkMode] = useState(false);
+  const [highlightColor, setHighlightColor] = useState('green');
 
   const lightTokens = {
     colorBgBase: '#ffffff',
     colorBgContainer: '#ffffff',
     colorTextBase: '#000000',
     colorText: '#000000',
-    colorPrimary: '#547b5f',
+    colorPrimary: HIGHLIGHT_COLORS[highlightColor].light,
   };
 
   const darkTokens = {
@@ -23,19 +34,23 @@ export default function ThemeProvider({ children }) {
     colorBgContainer: '#1f1f1f',
     colorTextBase: '#ffffff',
     colorText: '#ffffff',
-    colorPrimary: '#547b5f',
+    colorPrimary: HIGHLIGHT_COLORS[highlightColor].dark,
   };
 
   // Initialize theme from localStorage or matchMedia
   useEffect(() => {
     if (typeof window === 'undefined') return;
-    const stored = localStorage.getItem('theme');
-    if (stored) {
-      setDarkMode(stored === 'dark');
+    const storedTheme = localStorage.getItem('theme');
+    if (storedTheme) {
+      setDarkMode(storedTheme === 'dark');
     } else {
-      const prefersDark = window.matchMedia &&
-        window.matchMedia('(prefers-color-scheme: dark)').matches;
+      const prefersDark =
+        window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
       setDarkMode(prefersDark);
+    }
+    const storedHighlight = localStorage.getItem('highlightColor');
+    if (storedHighlight && HIGHLIGHT_COLORS[storedHighlight]) {
+      setHighlightColor(storedHighlight);
     }
   }, []);
 
@@ -45,6 +60,14 @@ export default function ThemeProvider({ children }) {
     localStorage.setItem('theme', darkMode ? 'dark' : 'light');
     document.body.setAttribute('data-theme', darkMode ? 'dark' : 'light');
   }, [darkMode]);
+
+  // Persist highlight color and update CSS variable
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    localStorage.setItem('highlightColor', highlightColor);
+    const value = HIGHLIGHT_COLORS[highlightColor][darkMode ? 'dark' : 'light'];
+    document.body.style.setProperty('--highlight-color', value);
+  }, [highlightColor, darkMode]);
 
   const toggleTheme = () => {
     setDarkMode((prev) => !prev);
@@ -90,7 +113,7 @@ export default function ThemeProvider({ children }) {
         },
       }}
     >
-      <ThemeContext.Provider value={{ darkMode, toggleTheme }}>
+      <ThemeContext.Provider value={{ darkMode, toggleTheme, highlightColor, setHighlightColor }}>
         {children}
       </ThemeContext.Provider>
     </ConfigProvider>

--- a/src/components/Tree/EntryCard.module.css
+++ b/src/components/Tree/EntryCard.module.css
@@ -30,10 +30,6 @@ body[data-theme="dark"] .card {
 
 .interactive {}
 
-.card:hover {
-  background-color: color-mix(in oklab, var(--ant-colorBgContainer) 90%, var(--ant-colorPrimary));
-}
-
 .card.interactive:hover {
   --scale: 1.02;
 }

--- a/src/components/Tree/GroupCard.module.css
+++ b/src/components/Tree/GroupCard.module.css
@@ -30,10 +30,6 @@ body[data-theme="dark"] .card {
 
 .interactive {}
 
-.card:hover {
-  background-color: color-mix(in oklab, var(--ant-colorBgContainer) 90%, var(--ant-colorPrimary));
-}
-
 .card.interactive:hover {
   --scale: 1.02;
 }

--- a/src/components/Tree/SubgroupCard.module.css
+++ b/src/components/Tree/SubgroupCard.module.css
@@ -30,10 +30,6 @@ body[data-theme="dark"] .card {
 
 .interactive {}
 
-.card:hover {
-  background-color: color-mix(in oklab, var(--ant-colorBgContainer) 90%, var(--ant-colorPrimary));
-}
-
 .card.interactive:hover {
   --scale: 1.02;
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,6 +1,10 @@
 @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+Symbols&display=swap');
 
+:root {
+  --highlight-color: #547b5f;
+}
+
 body {
   font-family: 'IBM Plex Mono', 'Cutive Mono', monospace;
   margin: 0;
@@ -657,10 +661,16 @@ button {
   user-select: none;
 }
 
-.interactive:hover {
+.interactive:hover,
+button:hover {
   cursor: pointer;
   transform: scale(1.02);
-  filter: brightness(0.95);
+  background-color: color-mix(in srgb, var(--highlight-color) 15%, transparent);
+  border-color: var(--highlight-color);
+  color: var(--highlight-color);
+}
+
+.interactive:hover {
   margin-left: 2rem;
   margin-right: 2rem;
 }
@@ -678,24 +688,6 @@ button {
 .entry-header.interactive:hover {
   margin-left: 0rem;
   margin-right: 0rem;
-}
-
-
-button:hover {
-  cursor: pointer;
-  transform: scale(1.02);
-  filter: brightness(0.95);
-}
-
-body[data-theme='light'] .interactive:hover,
-body[data-theme='light'] button:hover {
-  background-color: #f0f0f0;
-}
-
-body[data-theme='dark'] .interactive:hover,
-body[data-theme='dark'] button:hover {
-  background-color: #262626;
-  filter: brightness(1.1);
 }
 
 .edit-button {


### PR DESCRIPTION
## Summary
- centralize hover styling with --highlight-color variable
- allow users to pick highlight color and persist preference
- remove hardcoded green hover treatments

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689cc823fa8c832db5aa978596da94c2