### PR TITLE
feat: show pointer on entry snippet

### DIFF
--- a/src/components/Tree/EntryCard.module.css
+++ b/src/components/Tree/EntryCard.module.css
@@ -41,6 +41,7 @@ body[data-theme="dark"] .card {
 .snippet {
   font-size: 1rem;
   margin-top: 0.5rem;
+  cursor: pointer;
 }
 
 .actions {

--- a/src/components/Tree/EntryCard.test.jsx
+++ b/src/components/Tree/EntryCard.test.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DndContext } from '@dnd-kit/core';
+import EntryCard from './EntryCard';
+
+describe('EntryCard snippet interactions', () => {
+  it('calls onEdit when snippet is clicked', async () => {
+    const user = userEvent.setup();
+    const onEdit = jest.fn();
+    const entry = { id: '1', title: 'Title', snippet: 'Snippet text' };
+
+    render(
+      <DndContext>
+        <EntryCard id="1" entry={entry} isOpen onEdit={onEdit} />
+      </DndContext>
+    );
+
+    const snippet = screen.getByText('Snippet text');
+    await user.click(snippet);
+
+    expect(onEdit).toHaveBeenCalledWith(entry);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add pointer cursor to entry snippet
- test that snippet click triggers edit handler

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689d1a13ffb8832dad6c1043f6b235f9