### PR TITLE
Auto-hide drawer in FullScreenCanvas

### DIFF
--- a/src/components/Editor/FullScreenCanvas.jsx
+++ b/src/components/Editor/FullScreenCanvas.jsx
@@ -1,5 +1,5 @@
 // src/components/Editor/FullScreenCanvas.jsx
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import Drawer from '@/components/Drawer/Drawer';
 
 /**
@@ -14,6 +14,38 @@ export default function FullScreenCanvas({
   children,
   drawerProps,
 }) {
+  const [showDrawer, setShowDrawer] = useState(() => !!drawerProps);
+  const hideTimeoutRef = useRef(null);
+  const firstRunRef = useRef(true);
+  const hasDrawer = !!drawerProps;
+  const drawerOpen = drawerProps?.open;
+
+  useEffect(() => {
+    if (!hasDrawer) return;
+    hideTimeoutRef.current = setTimeout(() => {
+      setShowDrawer(false);
+    }, 2000);
+    return () => {
+      if (hideTimeoutRef.current) {
+        clearTimeout(hideTimeoutRef.current);
+        hideTimeoutRef.current = null;
+      }
+    };
+  }, [hasDrawer]);
+
+  useEffect(() => {
+    if (!hasDrawer) return;
+    if (firstRunRef.current) {
+      firstRunRef.current = false;
+      return;
+    }
+    if (hideTimeoutRef.current) {
+      clearTimeout(hideTimeoutRef.current);
+      hideTimeoutRef.current = null;
+    }
+    setShowDrawer(!!drawerOpen);
+  }, [hasDrawer, drawerOpen]);
+
   if (!open) return null;
 
   const overlayClass = `editor-modal-overlay fullscreen ${className}`.trim();
@@ -27,7 +59,7 @@ export default function FullScreenCanvas({
   return (
     <div className={overlayClass} onClick={handleClick}>
       {children}
-      {drawerProps && <Drawer {...drawerProps} />}
+      {drawerProps && <Drawer {...drawerProps} open={showDrawer} />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show editor drawer by default then auto-hide after 2s
- sync drawer visibility with parent state for manual toggling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689d6ad7143c832da67458693f65106f