### PR TITLE
feat: add editor autosave

### DIFF
--- a/src/components/Desk/DeskSurface.jsx
+++ b/src/components/Desk/DeskSurface.jsx
@@ -550,13 +550,34 @@ export default function DeskSurface({
     handleCancel(true);
   };
 
+  // Autosave every 30 seconds while the editor is open.
+  useEffect(() => {
+    if (!(editorState.isOpen && editorState.type === 'entry')) return;
+    let retries = 0;
+    const MAX_RETRIES = 3;
+    const interval = setInterval(() => {
+      const hasTitle = title.trim().length > 0;
+      const hasContent = content.trim().length > 0;
+      if (hasTitle && hasContent) {
+        handleNotebookSave();
+        retries = 0;
+      } else if (retries >= MAX_RETRIES - 1) {
+        clearInterval(interval);
+      } else {
+        retries += 1;
+      }
+    }, 30000);
+    return () => clearInterval(interval);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editorState.isOpen, editorState.type, title, content]);
+
 
   const openEntry = (node, item) => {
     setTitle(item.title || '');
     setContent(item.content || '');
     setIsEditingTitle(false);
     setTitleInput('');
-    setLastSaved(null);
+    setLastSaved(item?.updatedAt ? new Date(item.updatedAt) : null);
     setControllerPinned(false);
     setControllerOpen(false);
     setDrawerOpen(true);

--- a/src/components/Editor/NotebookEditor.jsx
+++ b/src/components/Editor/NotebookEditor.jsx
@@ -102,7 +102,7 @@ export default function NotebookEditor({
                 </p>
               )}
               <div className="last-saved">
-                Last Autosave: {lastSaved ? lastSaved.toLocaleString() : 'no autosaves yet...'}
+                Saved at: {lastSaved ? lastSaved.toLocaleString() : 'not yet saved'}
               </div>
             </div>
             <ExportMenu quillRef={quillRef} content={content} />


### PR DESCRIPTION
## Summary
- autosave notebook entries every 30 seconds using `handleNotebookSave`
- initialize `lastSaved` from entry `updatedAt` and show save timestamp in editor header

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689d8412b540832db9a97bee52f4f292