### PR TITLE
Improve spacing and shadows in NotebookTree cards

### DIFF
--- a/src/components/Tree/AddEntryButton.jsx
+++ b/src/components/Tree/AddEntryButton.jsx
@@ -3,7 +3,11 @@ import { Button } from 'antd';
 
 export default function AddEntryButton({ groupKey, subgroupKey, subgroupTitle, onAddEntry }) {
   return (
-    <Button type="dashed" onClick={() => onAddEntry(groupKey, subgroupKey)}>
+    <Button
+      type="dashed"
+      onClick={() => onAddEntry(groupKey, subgroupKey)}
+      style={{ marginTop: '1.5rem' }}
+    >
       {`Add New Entry to Subgroup ${subgroupTitle}`}
     </Button>
   );

--- a/src/components/Tree/AddGroupButton.jsx
+++ b/src/components/Tree/AddGroupButton.jsx
@@ -3,7 +3,7 @@ import { Button } from 'antd';
 
 export default function AddGroupButton({ onAddGroup }) {
   return (
-    <Button type="dashed" onClick={onAddGroup} style={{ marginTop: '1rem' }}>
+    <Button type="dashed" onClick={onAddGroup} style={{ marginTop: '1.5rem' }}>
       Add New Group
     </Button>
   );

--- a/src/components/Tree/AddSubgroupButton.jsx
+++ b/src/components/Tree/AddSubgroupButton.jsx
@@ -3,7 +3,11 @@ import { Button } from 'antd';
 
 export default function AddSubgroupButton({ groupKey, groupTitle, onAddSubgroup }) {
   return (
-    <Button type="dashed" onClick={() => onAddSubgroup(groupKey)}>
+    <Button
+      type="dashed"
+      onClick={() => onAddSubgroup(groupKey)}
+      style={{ marginTop: '1.5rem' }}
+    >
       {`Add New Subgroup to ${groupTitle}`}
     </Button>
   );

--- a/src/components/Tree/EntryCard.module.css
+++ b/src/components/Tree/EntryCard.module.css
@@ -1,7 +1,7 @@
 .card {
   --scale: 1;
-  margin-bottom: 0.5rem;
-  padding: 1rem;
+  margin-bottom: 1.5rem;
+  padding: 1.5rem;
   /* Solid fallback if CSS vars are missing */
   background-color: #e0e0e0;
   /* Fallbacks for when Ant Design CSS vars exist */
@@ -11,8 +11,7 @@
   border: 0;
   border-radius: 1rem;
   user-select: none;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  box-shadow: 0 2px 4px color-mix(in srgb, var(--ant-colorText, #000000) 25%, transparent); /* ignored if color-mix or vars unsupported; rgba above remains */
+  box-shadow: 0 2px 4px #000000;
   transition:
     transform var(--ant-motion-duration-mid) ease,
     background-color var(--ant-motion-duration-mid) ease;
@@ -24,8 +23,7 @@ body[data-theme="dark"] .card {
   /* Fallbacks for when Ant Design CSS vars exist */
   background-color: var(--ant-colorBgContainer, #1f1f1f);
   background-color: color-mix(in srgb, var(--ant-colorBgContainer, #1f1f1f) 88%, var(--ant-colorText, #ffffff) 12%);
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
-  box-shadow: 0 2px 4px color-mix(in srgb, var(--ant-colorText, #ffffff) 25%, transparent);
+  box-shadow: 0 2px 4px #000000;
 }
 
 .interactive {}

--- a/src/components/Tree/GroupCard.module.css
+++ b/src/components/Tree/GroupCard.module.css
@@ -11,8 +11,7 @@
   border: 0;
   border-radius: 1rem;
   user-select: none;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  box-shadow: 0 2px 4px color-mix(in srgb, var(--ant-colorText, #000000) 25%, transparent); /* ignored if color-mix or vars unsupported; rgba above remains */
+  box-shadow: 0 2px 4px #000000;
   transition:
     transform var(--ant-motion-duration-mid) ease,
     background-color var(--ant-motion-duration-mid) ease;
@@ -24,8 +23,7 @@ body[data-theme="dark"] .card {
   /* Fallbacks for when Ant Design CSS vars exist */
   background-color: var(--ant-colorBgContainer, #1f1f1f);
   background-color: color-mix(in srgb, var(--ant-colorBgContainer, #1f1f1f) 96%, var(--ant-colorText, #ffffff) 4%);
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
-  box-shadow: 0 2px 4px color-mix(in srgb, var(--ant-colorText, #ffffff) 25%, transparent);
+  box-shadow: 0 2px 4px #000000;
 }
 
 .interactive {}

--- a/src/components/Tree/NotebookTree.jsx
+++ b/src/components/Tree/NotebookTree.jsx
@@ -411,13 +411,15 @@ export default function NotebookTree({
                         !reorderMode ||
                         openGroupId !== group.key ||
                         openSubgroupId !== null;
+                      const nonArchivedCount =
+                        sub.children?.filter((e) => !e.archived).length || 0;
                       return (
                         <SubgroupCard
                           key={sub.key}
                           id={sub.key}
                           disableDrag={subgroupDragDisabled}
                           ref={(el) => (subgroupRefs.current[sub.key] = el)}
-                          title={sub.title}
+                          title={`${sub.title} (${nonArchivedCount})`}
                           isOpen={manageMode || openSubgroupId === sub.key}
                           onToggle={() => handleSubgroupToggle(sub)}
                           manageMode={manageMode}

--- a/src/components/Tree/NotebookTree.test.jsx
+++ b/src/components/Tree/NotebookTree.test.jsx
@@ -15,10 +15,10 @@ describe('NotebookTree custom cards', () => {
       { title: 'Group 2', key: 'g2', children: [{ title: 'Sub 2', key: 's2' }] },
     ];
     render(<NotebookTree treeData={treeData} manageMode />);
-    expect(screen.getByText('Sub 1')).toBeInTheDocument();
-    expect(screen.getByText('Sub 2')).toBeInTheDocument();
+    expect(screen.getByText('Sub 1 (0)')).toBeInTheDocument();
+    expect(screen.getByText('Sub 2 (0)')).toBeInTheDocument();
     await user.click(screen.getByText('Group 1'));
-    expect(screen.getByText('Sub 1')).toBeInTheDocument();
+    expect(screen.getByText('Sub 1 (0)')).toBeInTheDocument();
   });
 
   it('does not render add buttons in manage mode', () => {
@@ -52,7 +52,7 @@ describe('NotebookTree custom cards', () => {
     rerender(<NotebookTree treeData={treeData} reorderMode />);
     expect(screen.getAllByRole('img', { name: 'holder' }).length).toBe(2);
     await user.click(screen.getByText('Group 1'));
-    await screen.findByText('Sub 1');
+    await screen.findByText('Sub 1 (0)');
     expect(screen.getAllByRole('img', { name: 'holder' }).length).toBe(1);
   });
 
@@ -112,8 +112,8 @@ describe('NotebookTree custom cards', () => {
     render(<Wrapper />);
 
     await user.click(screen.getByText('Group 1'));
-    await screen.findByText('Sub 1');
-    await user.click(screen.getByText('Sub 1'));
+    await screen.findByText('Sub 1 (1)');
+    await user.click(screen.getByText('Sub 1 (1)'));
     await screen.findByText('Entry 1');
     await user.click(screen.getByText('Entry 1'));
     await screen.findByRole('button', { name: /delete/i });

--- a/src/components/Tree/SubgroupCard.module.css
+++ b/src/components/Tree/SubgroupCard.module.css
@@ -11,8 +11,7 @@
   border: 0;
   border-radius: 1rem;
   user-select: none;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  box-shadow: 0 2px 4px color-mix(in srgb, var(--ant-colorText, #000000) 25%, transparent); /* ignored if color-mix or vars unsupported; rgba above remains */
+  box-shadow: 0 2px 4px #000000;
   transition:
     transform var(--ant-motion-duration-mid) ease,
     background-color var(--ant-motion-duration-mid) ease;
@@ -24,8 +23,7 @@ body[data-theme="dark"] .card {
   /* Fallbacks for when Ant Design CSS vars exist */
   background-color: var(--ant-colorBgContainer, #1f1f1f);
   background-color: color-mix(in srgb, var(--ant-colorBgContainer, #1f1f1f) 92%, var(--ant-colorText, #ffffff) 8%);
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
-  box-shadow: 0 2px 4px color-mix(in srgb, var(--ant-colorText, #ffffff) 25%, transparent);
+  box-shadow: 0 2px 4px #000000;
 }
 
 .interactive {}


### PR DESCRIPTION
## Summary
- Increase EntryCard spacing and padding
- Add margins around add buttons
- Show non-archived entry counts in Subgroup titles
- Use solid black box shadows on all tree cards

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689e3793707c832db72bbd00ce5dd951