### PR TITLE
feat: add drawer manager context

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -4,6 +4,7 @@ import { ConfigProvider } from 'antd';
 import '../src/styles/main.css';
 import 'antd/dist/reset.css';
 import ThemeProvider from '../src/components/ThemeProvider';
+import DrawerManager from '../src/components/Drawer/DrawerManager';
 
 export default function App(props) {
   const { Component, pageProps } = props;
@@ -11,9 +12,12 @@ export default function App(props) {
     <SessionProvider session={pageProps.session}>
       <ConfigProvider theme={{ cssVar: true }}>
         <ThemeProvider>
-          <Component {...pageProps} />
+          <DrawerManager>
+            <Component {...pageProps} />
+          </DrawerManager>
         </ThemeProvider>
       </ConfigProvider>
     </SessionProvider>
   );
 }
+

--- a/src/components/Drawer/DrawerManager.jsx
+++ b/src/components/Drawer/DrawerManager.jsx
@@ -1,0 +1,45 @@
+/* eslint-disable react-refresh/only-export-components */
+import React, { createContext, useReducer, useContext } from 'react';
+
+// Context to manage active drawer state
+export const DrawerContext = createContext();
+
+const initialState = { activeId: null, props: undefined };
+
+function reducer(state, action) {
+  switch (action.type) {
+    case 'OPEN':
+      return { activeId: action.id, props: action.props };
+    case 'CLOSE':
+      return { activeId: null, props: undefined };
+    default:
+      return state;
+  }
+}
+
+export default function DrawerManager({ children }) {
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  const openDrawer = (id, props) => dispatch({ type: 'OPEN', id, props });
+  const closeDrawer = () => dispatch({ type: 'CLOSE' });
+
+  return (
+    <DrawerContext.Provider value={{ ...state, openDrawer, closeDrawer }}>
+      {children}
+    </DrawerContext.Provider>
+  );
+}
+
+export function useDrawer(id) {
+  const context = useContext(DrawerContext);
+  const open = context.activeId === id;
+  const openDrawerWithId = (props) => context.openDrawer(id, props);
+
+  return {
+    open,
+    props: context.props,
+    openDrawer: openDrawerWithId,
+    closeDrawer: context.closeDrawer,
+  };
+}
+


### PR DESCRIPTION
## Summary
- add DrawerManager context with reducer-driven state
- expose useDrawer hook for components to open and close drawers
- wrap app with DrawerManager provider

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68bc7df87474832d9d78c5181e3d4a4c