### PR TITLE
refactor: use shared Drawer component

### DIFF
--- a/src/components/Drawer/templates.jsx
+++ b/src/components/Drawer/templates.jsx
@@ -7,13 +7,14 @@ import {
   Select,
   Input,
   Avatar,
-  Drawer as AntDrawer,
 } from 'antd';
 import { signOut } from 'next-auth/react';
 import { EditOutlined, UserOutlined } from '@ant-design/icons';
 import Link from 'next/link';
 import { ThemeContext } from '../ThemeProvider';
 import HighlightColorPicker from '../HighlightColorPicker';
+import Drawer from './Drawer';
+import { useDrawer } from './DrawerManager';
 
 /**
  * Template factory functions for Drawer.
@@ -128,13 +129,17 @@ function NotebookControllerContent({
 }) {
   const [notebooks, setNotebooks] = useState([]);
   const [selected, setSelected] = useState('');
-  const [drawerOpen, setDrawerOpen] = useState(false);
   const [newTitle, setNewTitle] = useState('');
   const [newDescription, setNewDescription] = useState('');
   const [newGroupAlias, setNewGroupAlias] = useState('');
   const [newSubgroupAlias, setNewSubgroupAlias] = useState('');
   const [newEntryAlias, setNewEntryAlias] = useState('');
   const { darkMode, toggleTheme } = useContext(ThemeContext);
+  const {
+    open: drawerOpen,
+    openDrawer: openNotebookDrawer,
+    closeDrawer: closeNotebookDrawer,
+  } = useDrawer('new-notebook');
 
   useEffect(() => {
     async function fetchNotebooks() {
@@ -193,7 +198,7 @@ function NotebookControllerContent({
       const newNb = await res.json();
       setNotebooks((prev) => [...prev, newNb]);
       setSelected(newNb.id);
-      setDrawerOpen(false);
+      closeNotebookDrawer();
       onSelect(newNb.id);
       if (typeof window !== 'undefined') {
         localStorage.setItem('lastNotebookId', newNb.id);
@@ -236,7 +241,7 @@ function NotebookControllerContent({
             </option>
           ))}
         </select>
-        <Button onClick={() => setDrawerOpen(true)} style={{ width: '100%' }}>
+        <Button onClick={openNotebookDrawer} style={{ width: '100%' }}>
           Add New
         </Button>
         <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
@@ -286,48 +291,52 @@ function NotebookControllerContent({
         </div>
         <Button onClick={() => signOut({ redirect: false })}>Logout</Button>
       </div>
-      <AntDrawer
-        title="New Notebook"
+      <Drawer
         open={drawerOpen}
-        onClose={() => setDrawerOpen(false)}
-      >
-        <Input
-          placeholder="Name"
-          value={newTitle}
-          onChange={(e) => setNewTitle(e.target.value)}
-          style={{ marginBottom: '0.5rem' }}
-        />
-        <Input.TextArea
-          placeholder="Description (optional)"
-          value={newDescription}
-          onChange={(e) => setNewDescription(e.target.value)}
-          style={{ marginBottom: '0.5rem' }}
-        />
-        <Input
-          placeholder="Group Alias"
-          value={newGroupAlias}
-          onChange={(e) => setNewGroupAlias(e.target.value)}
-          style={{ marginBottom: '0.5rem' }}
-        />
-        <Input
-          placeholder="Subgroup Alias"
-          value={newSubgroupAlias}
-          onChange={(e) => setNewSubgroupAlias(e.target.value)}
-          style={{ marginBottom: '0.5rem' }}
-        />
-        <Input
-          placeholder="Entry Alias"
-          value={newEntryAlias}
-          onChange={(e) => setNewEntryAlias(e.target.value)}
-          style={{ marginBottom: '0.5rem' }}
-        />
-        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '0.5rem' }}>
-          <Button onClick={() => setDrawerOpen(false)}>Cancel</Button>
-          <Button type="primary" onClick={handleCreateDrawer}>
-            Create
-          </Button>
-        </div>
-      </AntDrawer>
+        header={<h2 style={{ marginTop: 0 }}>New Notebook</h2>}
+        body={
+          <>
+            <Input
+              placeholder="Name"
+              value={newTitle}
+              onChange={(e) => setNewTitle(e.target.value)}
+              style={{ marginBottom: '0.5rem' }}
+            />
+            <Input.TextArea
+              placeholder="Description (optional)"
+              value={newDescription}
+              onChange={(e) => setNewDescription(e.target.value)}
+              style={{ marginBottom: '0.5rem' }}
+            />
+            <Input
+              placeholder="Group Alias"
+              value={newGroupAlias}
+              onChange={(e) => setNewGroupAlias(e.target.value)}
+              style={{ marginBottom: '0.5rem' }}
+            />
+            <Input
+              placeholder="Subgroup Alias"
+              value={newSubgroupAlias}
+              onChange={(e) => setNewSubgroupAlias(e.target.value)}
+              style={{ marginBottom: '0.5rem' }}
+            />
+            <Input
+              placeholder="Entry Alias"
+              value={newEntryAlias}
+              onChange={(e) => setNewEntryAlias(e.target.value)}
+              style={{ marginBottom: '0.5rem' }}
+            />
+          </>
+        }
+        footer={
+          <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '0.5rem' }}>
+            <Button onClick={closeNotebookDrawer}>Cancel</Button>
+            <Button type="primary" onClick={handleCreateDrawer}>
+              Create
+            </Button>
+          </div>
+        }
+      />
     </>
   );
 }

--- a/src/components/Tree/EntityEditDrawer.jsx
+++ b/src/components/Tree/EntityEditDrawer.jsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from 'react';
-import { Drawer, Input, Button, Select, Tag } from 'antd';
+import Drawer from '@/components/Drawer/Drawer';
+import { useDrawer } from '@/components/Drawer/DrawerManager';
+import { Input, Button, Select, Tag } from 'antd';
 
 /**
  * Drawer for editing a notebook tree entity.
@@ -9,12 +11,15 @@ import { Drawer, Input, Button, Select, Tag } from 'antd';
 export default function EntityEditDrawer({
   type,
   id,
-  open,
   initialData,
   onClose,
   onSave,
   subgroupOptions = [],
 }) {
+  const {
+    open,
+    closeDrawer,
+  } = useDrawer('entity-edit');
   const [title, setTitle] = useState(
     initialData?.title ?? initialData?.name ?? ''
   );
@@ -122,9 +127,10 @@ export default function EntityEditDrawer({
 
   const handleSave = async () => {
     let payload = {};
-    let endpoint = type === 'notebook'
-      ? `/api/notebooks/${id}`
-      : `/api/${type}s/${id}`;
+    let endpoint =
+      type === 'notebook'
+        ? `/api/notebooks/${id}`
+        : `/api/${type}s/${id}`;
 
     if (type === 'entry') {
       payload = {
@@ -153,12 +159,18 @@ export default function EntityEditDrawer({
       const data = await res.json();
       onSave?.(data);
     }
+    handleClose();
+  };
+
+  const handleClose = () => {
+    closeDrawer();
     onClose?.();
   };
 
-  return (
-    <Drawer open={open} onClose={onClose} title={`Edit ${type}`} zIndex={1002}>
-      {/* title field */}
+  const header = <h2 style={{ marginTop: 0 }}>{`Edit ${type}`}</h2>;
+
+  const body = (
+    <>
       <Input
         placeholder="Title"
         value={title}
@@ -245,14 +257,18 @@ export default function EntityEditDrawer({
           </Select>
         </>
       )}
-
-      <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '0.5rem' }}>
-        <Button onClick={onClose}>Cancel</Button>
-        <Button type="primary" onClick={handleSave}>
-          Save
-        </Button>
-      </div>
-    </Drawer>
+    </>
   );
+
+  const footer = (
+    <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '0.5rem' }}>
+      <Button onClick={handleClose}>Cancel</Button>
+      <Button type="primary" onClick={handleSave}>
+        Save
+      </Button>
+    </div>
+  );
+
+  return <Drawer open={open} header={header} body={body} footer={footer} zIndex={1002} />;
 }
 

--- a/src/components/Tree/NotebookTree.jsx
+++ b/src/components/Tree/NotebookTree.jsx
@@ -13,6 +13,7 @@ import AddSubgroupButton from './AddSubgroupButton';
 import AddEntryButton from './AddEntryButton';
 import EntityEditDrawer from './EntityEditDrawer';
 import styles from './Tree.module.css';
+import { useDrawer } from '@/components/Drawer/DrawerManager';
 
 const formatDate = (date) => (date ? new Date(date).toLocaleDateString() : '');
 
@@ -59,6 +60,10 @@ export default function NotebookTree({
   const [openEntryId, setOpenEntryId] = useState(null);
 
   const [editEntity, setEditEntity] = useState(null);
+  const {
+    openDrawer: openEditDrawer,
+    closeDrawer: closeEditDrawer,
+  } = useDrawer('entity-edit');
 
   // refs for scrolling
   const groupRefs = useRef({});
@@ -81,6 +86,7 @@ export default function NotebookTree({
     clearEditDrawerHide();
     editDrawerHideRef.current = setTimeout(() => {
       setEditEntity(null);
+      closeEditDrawer();
     }, 2000);
   };
 
@@ -101,6 +107,7 @@ export default function NotebookTree({
   const handleGroupToggle = async (group) => {
     if (manageMode) {
       setEditEntity({ type: 'group', id: group.key, data: group });
+      openEditDrawer();
       return;
     }
     const isCurrentlyOpen = openGroupId === group.key;
@@ -123,6 +130,7 @@ export default function NotebookTree({
   const handleSubgroupToggle = async (sub) => {
     if (manageMode) {
       setEditEntity({ type: 'subgroup', id: sub.key, data: sub });
+      openEditDrawer();
       return;
     }
     const isCurrentlyOpen = openSubgroupId === sub.key;
@@ -156,6 +164,7 @@ export default function NotebookTree({
         data: entry,
         subgroups: subs,
       });
+      openEditDrawer();
       return;
     }
     setOpenEntryId((prev) => (prev === entryId ? null : entryId));
@@ -495,11 +504,13 @@ export default function NotebookTree({
           <EntityEditDrawer
             type={editEntity.type}
             id={editEntity.id}
-            open={!!editEntity}
             initialData={editEntity.data}
             subgroupOptions={editEntity.subgroups}
             onSave={handleEntitySave}
-            onClose={() => setEditEntity(null)}
+            onClose={() => {
+              setEditEntity(null);
+              closeEditDrawer();
+            }}
           />
         </div>
       )}

--- a/src/components/Tree/NotebookTree.test.jsx
+++ b/src/components/Tree/NotebookTree.test.jsx
@@ -2,6 +2,9 @@ import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import NotebookTree from './NotebookTree';
+import DrawerManager from '../Drawer/DrawerManager';
+
+const renderWithDrawer = (ui) => render(<DrawerManager>{ui}</DrawerManager>);
 
 describe('NotebookTree custom cards', () => {
   beforeAll(() => {
@@ -14,7 +17,7 @@ describe('NotebookTree custom cards', () => {
       { title: 'Group 1', key: 'g1', children: [{ title: 'Sub 1', key: 's1' }] },
       { title: 'Group 2', key: 'g2', children: [{ title: 'Sub 2', key: 's2' }] },
     ];
-    render(<NotebookTree treeData={treeData} manageMode />);
+    renderWithDrawer(<NotebookTree treeData={treeData} manageMode />);
     expect(screen.getByText('Sub 1 (0)')).toBeInTheDocument();
     expect(screen.getByText('Sub 2 (0)')).toBeInTheDocument();
     await user.click(screen.getByText('Group 1'));
@@ -25,7 +28,7 @@ describe('NotebookTree custom cards', () => {
     const treeData = [
       { title: 'Group 1', key: 'g1', children: [{ title: 'Sub 1', key: 's1' }] },
     ];
-    render(
+    renderWithDrawer(
       <NotebookTree
         treeData={treeData}
         onAddGroup={() => {}}
@@ -47,9 +50,13 @@ describe('NotebookTree custom cards', () => {
       { title: 'Group 1', key: 'g1', children: [{ title: 'Sub 1', key: 's1' }] },
       { title: 'Group 2', key: 'g2', children: [] },
     ];
-    const { rerender } = render(<NotebookTree treeData={treeData} />);
+    const { rerender } = renderWithDrawer(<NotebookTree treeData={treeData} />);
     expect(screen.queryAllByRole('img', { name: 'holder' }).length).toBe(0);
-    rerender(<NotebookTree treeData={treeData} reorderMode />);
+    rerender(
+      <DrawerManager>
+        <NotebookTree treeData={treeData} reorderMode />
+      </DrawerManager>
+    );
     expect(screen.getAllByRole('img', { name: 'holder' }).length).toBe(2);
     await user.click(screen.getByText('Group 1'));
     await screen.findByText('Sub 1 (0)');
@@ -65,7 +72,7 @@ describe('NotebookTree custom cards', () => {
       json: async () => ({ name: 'Group 1', description: 'desc' }),
     });
 
-    render(<NotebookTree treeData={treeData} manageMode />);
+    renderWithDrawer(<NotebookTree treeData={treeData} manageMode />);
     await user.click(screen.getByText('Group 1'));
 
     const input = await screen.findByPlaceholderText('Title');
@@ -109,7 +116,7 @@ describe('NotebookTree custom cards', () => {
       const [data, setData] = React.useState(initialData);
       return <NotebookTree treeData={data} setTreeData={setData} />;
     };
-    render(<Wrapper />);
+    renderWithDrawer(<Wrapper />);
 
     await user.click(screen.getByText('Group 1'));
     await screen.findByText('Sub 1 (1)');


### PR DESCRIPTION
## Summary
- replace raw AntDrawer usage with shared Drawer component
- route add-group, new-notebook and entity-edit drawers through useDrawer
- wrap NotebookTree tests with DrawerManager

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68bdab0701f4832d810711ab2edf0a30