### PR TITLE
feat: add hover-aware drawer hook

### DIFF
--- a/src/hooks/useHoverDrawer.js
+++ b/src/hooks/useHoverDrawer.js
@@ -1,0 +1,65 @@
+import { useEffect, useRef, useContext } from 'react';
+import { DrawerContext } from '@/components/Drawer/DrawerManager';
+
+/**
+ * Hook to handle hover-driven drawers with optional pinning and auto close.
+ *
+ * @param {Object} options
+ * @param {string} options.id                 Unique drawer id used with DrawerContext
+ * @param {boolean} options.open              Current open state of the drawer
+ * @param {Function} options.openDrawer       Function that opens the drawer
+ * @param {Function} options.closeDrawer      Function that closes the drawer
+ * @param {boolean} [options.openOnHover]     Whether hovering should open the drawer
+ * @param {boolean} [options.pin]             If true, the drawer remains open
+ * @param {number} [options.autoCloseDelay]   Delay before auto closing after mouse leave
+ * @returns {{onMouseEnter: Function, onMouseLeave: Function}}
+ */
+export default function useHoverDrawer({
+  id,
+  open,
+  openDrawer,
+  closeDrawer,
+  openOnHover = false,
+  pin = false,
+  autoCloseDelay = 2000,
+}) {
+  const { activeId } = useContext(DrawerContext);
+  const timeoutRef = useRef(null);
+
+  const clear = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  };
+
+  const handleMouseEnter = () => {
+    if (!openOnHover || pin) return;
+    if (activeId && activeId !== id) return;
+    clear();
+    openDrawer();
+  };
+
+  const handleMouseLeave = () => {
+    if (pin) return;
+    clear();
+    timeoutRef.current = setTimeout(() => {
+      if (!pin) {
+        closeDrawer();
+      }
+    }, autoCloseDelay);
+  };
+
+  useEffect(() => {
+    if (pin && !open) {
+      clear();
+      openDrawer();
+    }
+  }, [pin, open, openDrawer]);
+
+  useEffect(() => {
+    return () => clear();
+  }, []);
+
+  return { onMouseEnter: handleMouseEnter, onMouseLeave: handleMouseLeave };
+}


### PR DESCRIPTION
## Summary
- add `useHoverDrawer` hook to manage hover, pinning, and auto-close for drawers
- refactor `DeskSurface` to use the hook for editor and controller drawers
- integrate drawer pin toggles and hover handlers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68bdb23240d8832db6fe813211b1dbb8