### PR TITLE
feat: centralize drawer opening

### DIFF
--- a/docs/drawers.md
+++ b/docs/drawers.md
@@ -1,0 +1,51 @@
+# Drawer types
+
+The `DrawerManager` exposes `openDrawerByType(type, extraProps)` for opening common drawers.
+Each type maps to an internal drawer id and may supply default props or a template.
+
+## editor
+- **id**: `editor`
+- **template**: `editor`
+- **props**: expects editor configuration such as `pomodoroEnabled`, `onPomodoroToggle`,
+  `fullFocus`, `onFullFocusToggle`, `maxWidth`, `onMaxWidthChange`, `type`, `mode`,
+  `aliases`, `groups`, `selectedSubgroupId`, `onChangeSubgroup`, `onSave`,
+  `onSaveAndClose`, `onDelete`, `onArchive`, `onCancel`, and `saving`.
+
+## controller
+- **id**: `controller`
+- **template**: `controller`
+- **props**: accepts controller options like `onSelect`, `showEdits`, `onToggleEdits`,
+  `reorderMode`, `onToggleReorder`, `fullFocus`, `onFullFocusToggle`, `showArchived`,
+  `onToggleArchived`, and `onAddNotebookDrawerChange`.
+
+## addGroup
+- **id**: `add-group`
+- **props**: `parentId` (notebook id). The drawer collects a name and optional description
+  for the new group.
+
+## addSubgroup
+- **id**: `add-group`
+- **props**: `parentId` (group id). Collects name and description for the new subgroup.
+
+## editGroup
+- **id**: `entity-edit`
+- **props**: `id`, `initialData`, `onSave`.
+
+## editSubgroup
+- **id**: `entity-edit`
+- **props**: `id`, `initialData`, `onSave`.
+
+## editEntry
+- **id**: `entity-edit`
+- **props**: `id`, `initialData`, `subgroupOptions`, `onSave`.
+
+## editNotebook
+- **id**: `entity-edit`
+- **props**: `id`, `initialData`, `onSave`.
+
+Use `extraProps` when calling `openDrawerByType` to supply the above parameters:
+
+```js
+const openDrawerByType = useDrawerByType();
+openDrawerByType('editEntry', { id: 'e1', initialData: entry });
+```

--- a/src/components/Drawer/DrawerManager.jsx
+++ b/src/components/Drawer/DrawerManager.jsx
@@ -6,6 +6,18 @@ export const DrawerContext = createContext();
 
 const initialState = { activeId: null, props: undefined };
 
+// Map logical drawer types to internal drawer ids and default props
+const typeMap = {
+  addGroup: { id: 'add-group', props: { type: 'group' } },
+  addSubgroup: { id: 'add-group', props: { type: 'subgroup' } },
+  editGroup: { id: 'entity-edit', props: { type: 'group' } },
+  editSubgroup: { id: 'entity-edit', props: { type: 'subgroup' } },
+  editEntry: { id: 'entity-edit', props: { type: 'entry' } },
+  editNotebook: { id: 'entity-edit', props: { type: 'notebook' } },
+  controller: { id: 'controller', props: { template: 'controller' } },
+  editor: { id: 'editor', props: { template: 'editor' } },
+};
+
 function reducer(state, action) {
   switch (action.type) {
     case 'OPEN':
@@ -21,10 +33,21 @@ export default function DrawerManager({ children }) {
   const [state, dispatch] = useReducer(reducer, initialState);
 
   const openDrawer = (id, props) => dispatch({ type: 'OPEN', id, props });
+  const openDrawerByType = (type, extraProps = {}) => {
+    const config = typeMap[type];
+    if (!config) {
+      console.warn(`Unknown drawer type: ${type}`);
+      return;
+    }
+    const props = { ...(config.props || {}), ...extraProps };
+    openDrawer(config.id, props);
+  };
   const closeDrawer = () => dispatch({ type: 'CLOSE' });
 
   return (
-    <DrawerContext.Provider value={{ ...state, openDrawer, closeDrawer }}>
+    <DrawerContext.Provider
+      value={{ ...state, openDrawer, openDrawerByType, closeDrawer }}
+    >
       {children}
     </DrawerContext.Provider>
   );
@@ -41,5 +64,10 @@ export function useDrawer(id) {
     openDrawer: openDrawerWithId,
     closeDrawer: context.closeDrawer,
   };
+}
+
+export function useDrawerByType() {
+  const context = useContext(DrawerContext);
+  return context.openDrawerByType;
 }
 

--- a/src/components/Tree/EntityEditDrawer.jsx
+++ b/src/components/Tree/EntityEditDrawer.jsx
@@ -8,18 +8,16 @@ import { Input, Button, Select, Tag } from 'antd';
  * Handles notebooks, groups, subgroups and entries with
  * type-specific fields.
  */
-export default function EntityEditDrawer({
-  type,
-  id,
-  initialData,
-  onClose,
-  onSave,
-  subgroupOptions = [],
-}) {
+export default function EntityEditDrawer() {
+  const { open, props = {}, closeDrawer } = useDrawer('entity-edit');
   const {
-    open,
-    closeDrawer,
-  } = useDrawer('entity-edit');
+    type,
+    id,
+    initialData,
+    onClose,
+    onSave,
+    subgroupOptions = [],
+  } = props || {};
   const [title, setTitle] = useState(
     initialData?.title ?? initialData?.name ?? ''
   );


### PR DESCRIPTION
## Summary
- add `openDrawerByType` helper for drawer context
- use typed drawer requests in `NotebookTree` and `DeskSurface`
- document drawer types and expected props

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68bdb803fe60832db5c778bab96779db