### PR TITLE
Refactor drawer hamburger interactions

### DIFF
--- a/src/components/Desk/DeskSurface.jsx
+++ b/src/components/Desk/DeskSurface.jsx
@@ -121,7 +121,7 @@ export default function DeskSurface({
       open: drawerOpen,
       openDrawer: openEditorDrawer,
       closeDrawer: closeEditorDrawer,
-      openOnHover: true,
+      openOnHover: false,
       pin: editorPinned,
       autoCloseDelay: 2000,
     });
@@ -134,7 +134,7 @@ export default function DeskSurface({
     open: controllerOpen,
     openDrawer: openControllerDrawer,
     closeDrawer: closeControllerDrawer,
-    openOnHover: true,
+    openOnHover: false,
     pin: controllerPinned,
     autoCloseDelay: 2000,
   });

--- a/src/components/Drawer/Drawer.jsx
+++ b/src/components/Drawer/Drawer.jsx
@@ -33,7 +33,7 @@ export default function Drawer({
 
   return (
     <>
-      {onHamburgerClick && (
+      {onHamburgerClick && !open && (
         <Button
           type="text"
           icon={<MenuOutlined />}
@@ -45,7 +45,7 @@ export default function Drawer({
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
         className="drawer-wrapper"
-        style={{ width }}
+        style={{ width: open ? width : 0 }}
       >
         <AntDrawer
           placement="right"
@@ -55,9 +55,17 @@ export default function Drawer({
           width={width}
           getContainer={false}
           rootStyle={{ position: 'absolute' }}
-          bodyStyle={{ padding: '1rem' }}
+          bodyStyle={{ padding: '1rem', position: 'relative' }}
           {...rest}
         >
+          {onHamburgerClick && open && (
+            <Button
+              type="text"
+              icon={<MenuOutlined />}
+              onClick={onHamburgerClick}
+              style={{ position: 'absolute', top: '1rem', left: '1rem', zIndex: 1 }}
+            />
+          )}
           {sections.header}
           {sections.body}
           {sections.footer}

--- a/src/hooks/useHoverDrawer.js
+++ b/src/hooks/useHoverDrawer.js
@@ -34,9 +34,10 @@ export default function useHoverDrawer({
   };
 
   const handleMouseEnter = () => {
-    if (!openOnHover || pin) return;
-    if (activeId && activeId !== id) return;
+    if (pin) return;
     clear();
+    if (!openOnHover) return;
+    if (activeId && activeId !== id) return;
     openDrawer();
   };
 


### PR DESCRIPTION
## Summary
- move hamburger button inside drawers when open and hide drawer hitbox when closed
- disable hover-open and ensure drawers open only when hamburger is clicked
- keep drawers responsive by clearing hover close timers on mouse enter

## Testing
- `npm test --silent 2>/dev/null | tail -n 5`


------
https://chatgpt.com/codex/tasks/task_b_68bdbe4beab8832daa8b5c63890d7f5f