### PR TITLE
fix: prevent controller drawer double-open

### DIFF
--- a/src/components/Desk/DeskSurface.jsx
+++ b/src/components/Desk/DeskSurface.jsx
@@ -498,9 +498,7 @@ export default function DeskSurface({
     if (showEdits) return;
     setControllerPinned((prev) => {
       const next = !prev;
-      if (next) {
-        openControllerDrawer();
-      } else {
+      if (!next) {
         closeControllerDrawer();
       }
       return next;


### PR DESCRIPTION
## Summary
- avoid double-opening controller drawer when toggling hamburger in Notebook surface

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68bddd1d1708832d9068b8ef8a1af198