### PR TITLE
Fix controller pin handling when opening add drawers

### DIFF
--- a/src/components/Desk/DeskSurface.jsx
+++ b/src/components/Desk/DeskSurface.jsx
@@ -299,11 +299,15 @@ export default function DeskSurface({
   const handleAddGroup = () => {
     if (!notebookId) return;
     setAddDrawerFields({ name: '', description: '' });
+    setControllerPinned(false);
+    closeControllerDrawer();
     openDrawerByType('addGroup', { parentId: notebookId });
   };
 
   const handleAddSubgroup = (groupId) => {
     setAddDrawerFields({ name: '', description: '' });
+    setControllerPinned(false);
+    closeControllerDrawer();
     openDrawerByType('addSubgroup', { parentId: groupId });
   };
 

--- a/src/hooks/useHoverDrawer.js
+++ b/src/hooks/useHoverDrawer.js
@@ -52,11 +52,11 @@ export default function useHoverDrawer({
   };
 
   useEffect(() => {
-    if (pin && !open) {
+    if (pin && !open && (!activeId || activeId === id)) {
       clear();
       openDrawer();
     }
-  }, [pin, open, openDrawer]);
+  }, [pin, open, openDrawer, activeId, id]);
 
   useEffect(() => {
     return () => clear();


### PR DESCRIPTION
## Summary
- close controller and unpin before opening add group or subgroup drawers
- guard pinned hover drawers from reopening when another drawer is active

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68bf63b5a3f4832d98cd80dfabaf0ed8