### PR TITLE
Fix Add Notebook drawer rendering

### DIFF
--- a/src/components/Drawer/Drawer.jsx
+++ b/src/components/Drawer/Drawer.jsx
@@ -18,6 +18,8 @@ export default function Drawer({
   body,
   footer,
   children,
+  destroyOnClose = false,
+  getContainer = false,
   ...rest
 }) {
   let sections = {
@@ -53,8 +55,9 @@ export default function Drawer({
           mask={false}
           closable={false}
           width={width}
-          getContainer={false}
-          rootStyle={{ position: 'absolute' }}
+          getContainer={getContainer}
+          destroyOnClose={destroyOnClose}
+          rootStyle={getContainer === false ? { position: 'absolute' } : undefined}
           bodyStyle={{ padding: '1rem', position: 'relative' }}
           {...rest}
         >

--- a/src/components/Drawer/templates.jsx
+++ b/src/components/Drawer/templates.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable react-refresh/only-export-components */
 import React, { useState, useEffect, useContext } from 'react';
+import { createPortal } from 'react-dom';
 import {
   Button,
   Switch,
@@ -291,52 +292,58 @@ function NotebookControllerContent({
         </div>
         <Button onClick={() => signOut({ redirect: false })}>Logout</Button>
       </div>
-      <Drawer
-        open={drawerOpen}
-        header={<h2 style={{ marginTop: 0 }}>New Notebook</h2>}
-        body={
-          <>
-            <Input
-              placeholder="Name"
-              value={newTitle}
-              onChange={(e) => setNewTitle(e.target.value)}
-              style={{ marginBottom: '0.5rem' }}
-            />
-            <Input.TextArea
-              placeholder="Description (optional)"
-              value={newDescription}
-              onChange={(e) => setNewDescription(e.target.value)}
-              style={{ marginBottom: '0.5rem' }}
-            />
-            <Input
-              placeholder="Group Alias"
-              value={newGroupAlias}
-              onChange={(e) => setNewGroupAlias(e.target.value)}
-              style={{ marginBottom: '0.5rem' }}
-            />
-            <Input
-              placeholder="Subgroup Alias"
-              value={newSubgroupAlias}
-              onChange={(e) => setNewSubgroupAlias(e.target.value)}
-              style={{ marginBottom: '0.5rem' }}
-            />
-            <Input
-              placeholder="Entry Alias"
-              value={newEntryAlias}
-              onChange={(e) => setNewEntryAlias(e.target.value)}
-              style={{ marginBottom: '0.5rem' }}
-            />
-          </>
-        }
-        footer={
-          <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '0.5rem' }}>
-            <Button onClick={closeNotebookDrawer}>Cancel</Button>
-            <Button type="primary" onClick={handleCreateDrawer}>
-              Create
-            </Button>
-          </div>
-        }
-      />
+      {typeof document !== 'undefined' &&
+        createPortal(
+          <Drawer
+            open={drawerOpen}
+            header={<h2 style={{ marginTop: 0 }}>New Notebook</h2>}
+            body={
+              <>
+                <Input
+                  placeholder="Name"
+                  value={newTitle}
+                  onChange={(e) => setNewTitle(e.target.value)}
+                  style={{ marginBottom: '0.5rem' }}
+                />
+                <Input.TextArea
+                  placeholder="Description (optional)"
+                  value={newDescription}
+                  onChange={(e) => setNewDescription(e.target.value)}
+                  style={{ marginBottom: '0.5rem' }}
+                />
+                <Input
+                  placeholder="Group Alias"
+                  value={newGroupAlias}
+                  onChange={(e) => setNewGroupAlias(e.target.value)}
+                  style={{ marginBottom: '0.5rem' }}
+                />
+                <Input
+                  placeholder="Subgroup Alias"
+                  value={newSubgroupAlias}
+                  onChange={(e) => setNewSubgroupAlias(e.target.value)}
+                  style={{ marginBottom: '0.5rem' }}
+                />
+                <Input
+                  placeholder="Entry Alias"
+                  value={newEntryAlias}
+                  onChange={(e) => setNewEntryAlias(e.target.value)}
+                  style={{ marginBottom: '0.5rem' }}
+                />
+              </>
+            }
+            footer={
+              <div
+                style={{ display: 'flex', justifyContent: 'flex-end', gap: '0.5rem' }}
+              >
+                <Button onClick={closeNotebookDrawer}>Cancel</Button>
+                <Button type="primary" onClick={handleCreateDrawer}>
+                  Create
+                </Button>
+              </div>
+            }
+          />,
+          document.body
+        )}
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Allow Drawer to accept custom container and preserve contents when closing
- Render "Add Notebook" drawer through a portal so it no longer disappears when replacing the root controller drawer

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c0251ed350832db1208cca8697593f