### PR TITLE
feat: centralize drawer add actions

### DIFF
--- a/src/components/Desk/DeskSurface.jsx
+++ b/src/components/Desk/DeskSurface.jsx
@@ -17,6 +17,7 @@ import {
 import { Input, Button } from 'antd';
 import PomodoroWidget from '@/components/PomodoroWidget';
 import useHoverDrawer from '@/hooks/useHoverDrawer';
+import useDrawerActions from '@/hooks/useDrawerActions';
 
 function updateTreeData(list, key, children) {
   return list.map((node) => {
@@ -296,39 +297,18 @@ export default function DeskSurface({
       .catch((err) => console.error('Failed to reload entries', err));
   };
 
-  const handleAddGroup = () => {
-    if (!notebookId) return;
-    setAddDrawerFields({ name: '', description: '' });
-    setControllerPinned(false);
-    closeControllerDrawer();
-    openDrawerByType('addGroup', { parentId: notebookId });
-  };
-
-  const handleAddSubgroup = (groupId) => {
-    setAddDrawerFields({ name: '', description: '' });
-    setControllerPinned(false);
-    closeControllerDrawer();
-    openDrawerByType('addSubgroup', { parentId: groupId });
-  };
-
-  const handleAddEntry = (groupId, subgroupId) => {
-    setTitle('');
-    setContent('');
-    setIsEditingTitle(true);
-    setTitleInput('');
-    setLastSaved(null);
-    closeControllerDrawer();
-    setControllerPinned(false);
-    openEditorDrawer();
-    setEditorPinned(true);
-    setEditorState({
-      isOpen: true,
-      type: 'entry',
-      parent: { groupId, subgroupId },
-      item: null,
-      mode: 'create',
-    });
-  };
+  const { openAddGroup, openAddSubgroup, openAddEntry } = useDrawerActions({
+    setAddDrawerFields,
+    setTitle,
+    setContent,
+    setIsEditingTitle,
+    setTitleInput,
+    setLastSaved,
+    setEditorState,
+    setEditorPinned,
+    setControllerPinned,
+    openEditorDrawer,
+  });
 
   const handleAddDrawerClose = () => {
     setAddDrawerFields({ name: '', description: '' });
@@ -640,9 +620,9 @@ export default function DeskSurface({
     manageMode: showEdits,
     reorderMode,
     showArchived,
-    onAddGroup: showEdits ? undefined : handleAddGroup,
-    onAddSubgroup: showEdits ? undefined : handleAddSubgroup,
-    onAddEntry: showEdits ? undefined : handleAddEntry,
+    openAddGroup: showEdits ? undefined : () => openAddGroup(notebookId),
+    openAddSubgroup: showEdits ? undefined : openAddSubgroup,
+    openAddEntry: showEdits ? undefined : openAddEntry,
     onEdit: showEdits ? undefined : handleEditEntry,
     notebookId,
     previewEntry,

--- a/src/components/Tree/NotebookTree.jsx
+++ b/src/components/Tree/NotebookTree.jsx
@@ -25,9 +25,9 @@ const formatDate = (date) => (date ? new Date(date).toLocaleDateString() : '');
 export default function NotebookTree({
   treeData = [],
   setTreeData,
-  onAddGroup,
-  onAddSubgroup,
-  onAddEntry,
+  openAddGroup,
+  openAddSubgroup,
+  openAddEntry,
   onEdit,
   notebookId,
   loadData,
@@ -473,12 +473,12 @@ export default function NotebookTree({
                               })}
                             </SortableContext>
                           </DndContext>
-                          {!manageMode && onAddEntry && (
+                {!manageMode && openAddEntry && (
                             <AddEntryButton
                               groupKey={group.key}
                               subgroupKey={sub.key}
                               subgroupTitle={sub.title}
-                              onAddEntry={onAddEntry}
+                              onAddEntry={openAddEntry}
                             />
                           )}
                         </SubgroupCard>
@@ -486,11 +486,11 @@ export default function NotebookTree({
                     })}
                   </SortableContext>
                 </DndContext>
-                {!manageMode && onAddSubgroup && (
+                {!manageMode && openAddSubgroup && (
                   <AddSubgroupButton
                     groupKey={group.key}
                     groupTitle={group.title}
-                    onAddSubgroup={onAddSubgroup}
+                    onAddSubgroup={openAddSubgroup}
                   />
                 )}
               </GroupCard>
@@ -498,7 +498,7 @@ export default function NotebookTree({
           })}
         </SortableContext>
       </DndContext>
-      {!manageMode && onAddGroup && <AddGroupButton onAddGroup={onAddGroup} />}
+      {!manageMode && openAddGroup && <AddGroupButton onAddGroup={openAddGroup} />}
       {editDrawerOpen && (
         <div
           onMouseEnter={handleEditDrawerMouseEnter}

--- a/src/components/Tree/NotebookTree.test.jsx
+++ b/src/components/Tree/NotebookTree.test.jsx
@@ -31,9 +31,9 @@ describe('NotebookTree custom cards', () => {
     renderWithDrawer(
       <NotebookTree
         treeData={treeData}
-        onAddGroup={() => {}}
-        onAddSubgroup={() => {}}
-        onAddEntry={() => {}}
+        openAddGroup={() => {}}
+        openAddSubgroup={() => {}}
+        openAddEntry={() => {}}
         manageMode
       />
     );

--- a/src/hooks/useDrawerActions.js
+++ b/src/hooks/useDrawerActions.js
@@ -1,0 +1,61 @@
+import { useDrawer, useDrawerByType } from '@/components/Drawer/DrawerManager';
+
+export default function useDrawerActions({
+  setAddDrawerFields,
+  setTitle,
+  setContent,
+  setIsEditingTitle,
+  setTitleInput,
+  setLastSaved,
+  setEditorState,
+  setEditorPinned,
+  setControllerPinned,
+  openEditorDrawer,
+}) {
+  const openDrawerByType = useDrawerByType();
+  const { closeDrawer: closeControllerDrawer } = useDrawer('controller');
+
+  const resetAddFields = () => {
+    if (setAddDrawerFields) {
+      setAddDrawerFields({ name: '', description: '' });
+    }
+  };
+
+  const openAddGroup = (notebookId) => {
+    if (!notebookId) return;
+    resetAddFields();
+    setControllerPinned && setControllerPinned(false);
+    closeControllerDrawer();
+    openDrawerByType('addGroup', { parentId: notebookId });
+  };
+
+  const openAddSubgroup = (groupId) => {
+    resetAddFields();
+    setControllerPinned && setControllerPinned(false);
+    closeControllerDrawer();
+    openDrawerByType('addSubgroup', { parentId: groupId });
+  };
+
+  const openAddEntry = (groupId, subgroupId) => {
+    setTitle && setTitle('');
+    setContent && setContent('');
+    setIsEditingTitle && setIsEditingTitle(true);
+    setTitleInput && setTitleInput('');
+    setLastSaved && setLastSaved(null);
+    closeControllerDrawer();
+    setControllerPinned && setControllerPinned(false);
+    openEditorDrawer && openEditorDrawer();
+    setEditorPinned && setEditorPinned(true);
+    setEditorState &&
+      setEditorState({
+        isOpen: true,
+        type: 'entry',
+        parent: { groupId, subgroupId },
+        item: null,
+        mode: 'create',
+      });
+  };
+
+  return { openAddGroup, openAddSubgroup, openAddEntry };
+}
+


### PR DESCRIPTION
## Summary
- add `useDrawerActions` hook providing openAddGroup, openAddSubgroup, openAddEntry
- refactor `DeskSurface` and `NotebookTree` to use centralized drawer actions
- update tests for new props

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68bf65ba15d8832d812d26c24f6433f4