### PR TITLE
Collapse tree during reorder and restore previous state

### DIFF
--- a/src/components/Tree/NotebookTree.jsx
+++ b/src/components/Tree/NotebookTree.jsx
@@ -59,6 +59,30 @@ export default function NotebookTree({
   const [openSubgroupId, setOpenSubgroupId] = useState(null);
   const [openEntryId, setOpenEntryId] = useState(null);
 
+  // remember open state when toggling reorder mode
+  const prevOpenStateRef = useRef({ group: null, subgroup: null, entry: null });
+
+  useEffect(() => {
+    if (reorderMode) {
+      // store current state and collapse all to enable dragging
+      prevOpenStateRef.current = {
+        group: openGroupId,
+        subgroup: openSubgroupId,
+        entry: openEntryId,
+      };
+      setOpenGroupId(null);
+      setOpenSubgroupId(null);
+      setOpenEntryId(null);
+    } else {
+      // restore previously open entities
+      const { group, subgroup, entry } = prevOpenStateRef.current;
+      setOpenGroupId(group);
+      setOpenSubgroupId(subgroup);
+      setOpenEntryId(entry);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [reorderMode]);
+
   const openDrawerByType = useDrawerByType();
   const { open: editDrawerOpen, closeDrawer: closeEditDrawer } = useDrawer(
     'entity-edit'

--- a/src/components/Tree/NotebookTree.test.jsx
+++ b/src/components/Tree/NotebookTree.test.jsx
@@ -63,6 +63,47 @@ describe('NotebookTree custom cards', () => {
     expect(screen.getAllByRole('img', { name: 'holder' }).length).toBe(1);
   });
 
+  it('collapses and restores open state when toggling reorder mode', async () => {
+    const user = userEvent.setup();
+    const treeData = [
+      {
+        title: 'Group 1',
+        key: 'g1',
+        children: [
+          {
+            title: 'Sub 1',
+            key: 's1',
+            children: [{ title: 'Entry 1', key: 'e1', id: 'e1' }],
+          },
+        ],
+      },
+    ];
+    const { rerender } = renderWithDrawer(<NotebookTree treeData={treeData} />);
+
+    await user.click(screen.getByText('Group 1'));
+    await screen.findByText('Sub 1 (1)');
+    await user.click(screen.getByText('Sub 1 (1)'));
+    await screen.findByText('Entry 1');
+
+    rerender(
+      <DrawerManager>
+        <NotebookTree treeData={treeData} reorderMode />
+      </DrawerManager>
+    );
+
+    await waitFor(() => expect(screen.queryByText('Sub 1 (1)')).toBeNull());
+    await waitFor(() => expect(screen.queryByText('Entry 1')).toBeNull());
+
+    rerender(
+      <DrawerManager>
+        <NotebookTree treeData={treeData} />
+      </DrawerManager>
+    );
+
+    await screen.findByText('Sub 1 (1)');
+    await screen.findByText('Entry 1');
+  });
+
   it('loads existing values into entity edit drawer', async () => {
     const user = userEvent.setup();
     const treeData = [{ title: 'Group 1', key: 'g1', children: [] }];


### PR DESCRIPTION
## Summary
- collapse groups/subgroups when entering reorder mode so drag handles appear
- restore previously opened items when leaving reorder mode
- cover reorder toggle behavior with a new NotebookTree test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c58d73f51c832db9d48b68e25c3300