### PR TITLE
feat: centralize action handlers

### DIFF
--- a/src/components/Desk/DeskSurface.jsx
+++ b/src/components/Desk/DeskSurface.jsx
@@ -17,6 +17,12 @@ import {
 import { Input, Button } from 'antd';
 import PomodoroWidget from '@/components/PomodoroWidget';
 import useHoverDrawer from '@/hooks/useHoverDrawer';
+import {
+  createAddGroupHandler,
+  createAddSubgroupHandler,
+  createAddEntryHandler,
+  createEditEntryHandler,
+} from '@/utils/actionHandlers';
 
 function updateTreeData(list, key, children) {
   return list.map((node) => {
@@ -296,39 +302,33 @@ export default function DeskSurface({
       .catch((err) => console.error('Failed to reload entries', err));
   };
 
-  const handleAddGroup = () => {
-    if (!notebookId) return;
-    setAddDrawerFields({ name: '', description: '' });
-    setControllerPinned(false);
-    closeControllerDrawer();
-    openDrawerByType('addGroup', { parentId: notebookId });
-  };
+  const handleAddGroup = createAddGroupHandler({
+    notebookId,
+    openDrawerByType,
+    closeControllerDrawer,
+    setControllerPinned,
+    setAddDrawerFields,
+  });
 
-  const handleAddSubgroup = (groupId) => {
-    setAddDrawerFields({ name: '', description: '' });
-    setControllerPinned(false);
-    closeControllerDrawer();
-    openDrawerByType('addSubgroup', { parentId: groupId });
-  };
+  const handleAddSubgroup = createAddSubgroupHandler({
+    openDrawerByType,
+    closeControllerDrawer,
+    setControllerPinned,
+    setAddDrawerFields,
+  });
 
-  const handleAddEntry = (groupId, subgroupId) => {
-    setTitle('');
-    setContent('');
-    setIsEditingTitle(true);
-    setTitleInput('');
-    setLastSaved(null);
-    closeControllerDrawer();
-    setControllerPinned(false);
-    openEditorDrawer();
-    setEditorPinned(true);
-    setEditorState({
-      isOpen: true,
-      type: 'entry',
-      parent: { groupId, subgroupId },
-      item: null,
-      mode: 'create',
-    });
-  };
+  const handleAddEntry = createAddEntryHandler({
+    setTitle,
+    setContent,
+    setIsEditingTitle,
+    setTitleInput,
+    setLastSaved,
+    closeControllerDrawer,
+    setControllerPinned,
+    openEditorDrawer,
+    setEditorPinned,
+    setEditorState,
+  });
 
   const handleAddDrawerClose = () => {
     setAddDrawerFields({ name: '', description: '' });
@@ -607,14 +607,7 @@ export default function DeskSurface({
       mode: 'edit',
     });
   };
-
-  const handleEditEntry = async (entry) => {
-    const res = await fetch(`/api/entries/${entry.id}`);
-    const item = res.ok
-      ? await res.json()
-      : { id: entry.id, title: entry.title, content: '' };
-    openEntry(entry, item);
-  };
+  const handleEditEntry = createEditEntryHandler(openEntry);
 
   const handleNodeSelect = async (keys, info) => {
     const node = info.node;

--- a/src/components/Tree/NotebookTree.jsx
+++ b/src/components/Tree/NotebookTree.jsx
@@ -14,6 +14,7 @@ import AddEntryButton from './AddEntryButton';
 import EntityEditDrawer from './EntityEditDrawer';
 import styles from './Tree.module.css';
 import { useDrawer, useDrawerByType } from '@/components/Drawer/DrawerManager';
+import { createEntryDeleteHandler } from '@/utils/actionHandlers';
 
 const formatDate = (date) => (date ? new Date(date).toLocaleDateString() : '');
 
@@ -366,27 +367,10 @@ export default function NotebookTree({
     }
   };
 
-  const handleEntryDelete = (entry) => {
-    if (!setTreeData) return;
-    setTreeData((groups) =>
-      groups.map((g) => {
-        if (g.key !== entry.groupId) return g;
-        return {
-          ...g,
-          children: g.children?.map((s) => {
-            if (s.key !== entry.subgroupId) return s;
-            return {
-              ...s,
-              children: (s.children || []).filter(
-                (e) => e.key !== entry.key && e.id !== entry.id
-              ),
-            };
-          }),
-        };
-      })
-    );
-    setOpenEntryId((prev) => (prev === entry.id ? null : prev));
-  };
+  const handleEntryDelete = createEntryDeleteHandler({
+    setTreeData,
+    setOpenEntryId,
+  });
 
   return (
     <div className={styles.root}>

--- a/src/utils/actionHandlers.js
+++ b/src/utils/actionHandlers.js
@@ -1,0 +1,77 @@
+export const createAddGroupHandler = ({ notebookId, openDrawerByType, closeControllerDrawer, setControllerPinned, setAddDrawerFields }) => () => {
+  if (!notebookId) return;
+  setAddDrawerFields({ name: '', description: '' });
+  setControllerPinned(false);
+  closeControllerDrawer();
+  openDrawerByType('addGroup', { parentId: notebookId });
+};
+
+export const createAddSubgroupHandler = ({ openDrawerByType, closeControllerDrawer, setControllerPinned, setAddDrawerFields }) => (groupId) => {
+  setAddDrawerFields({ name: '', description: '' });
+  setControllerPinned(false);
+  closeControllerDrawer();
+  openDrawerByType('addSubgroup', { parentId: groupId });
+};
+
+export const createAddEntryHandler = ({
+  setTitle,
+  setContent,
+  setIsEditingTitle,
+  setTitleInput,
+  setLastSaved,
+  closeControllerDrawer,
+  setControllerPinned,
+  openEditorDrawer,
+  setEditorPinned,
+  setEditorState,
+}) => (groupId, subgroupId) => {
+  setTitle('');
+  setContent('');
+  setIsEditingTitle(true);
+  setTitleInput('');
+  setLastSaved(null);
+  closeControllerDrawer();
+  setControllerPinned(false);
+  openEditorDrawer();
+  setEditorPinned(true);
+  setEditorState({
+    isOpen: true,
+    type: 'entry',
+    parent: { groupId, subgroupId },
+    item: null,
+    mode: 'create',
+  });
+};
+
+export const createEditEntryHandler = (openEntry) => async (entry) => {
+  const res = await fetch(`/api/entries/${entry.id}`);
+  const item = res.ok
+    ? await res.json()
+    : { id: entry.id, title: entry.title, content: '' };
+  openEntry(entry, item);
+};
+
+export const createEntryDeleteHandler = ({ setTreeData, setOpenEntryId }) => (entry) => {
+  if (!setTreeData) return;
+  setTreeData((groups) =>
+    groups.map((g) => {
+      if (g.key !== entry.groupId) return g;
+      return {
+        ...g,
+        children: g.children?.map((s) => {
+          if (s.key !== entry.subgroupId) return s;
+          return {
+            ...s,
+            children: (s.children || []).filter(
+              (e) => e.key !== entry.key && e.id !== entry.id
+            ),
+          };
+        }),
+      };
+    })
+  );
+  if (setOpenEntryId) {
+    setOpenEntryId((prev) => (prev === entry.id ? null : prev));
+  }
+};
+


### PR DESCRIPTION
## Summary
- add shared action handlers for groups, subgroups, and entries
- refactor DeskSurface and NotebookTree to use centralized handlers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c59132dfd4832db69e8d92526ae627