### PR TITLE
Load subgroup entry counts on group expand

### DIFF
--- a/pages/api/subgroups/index.js
+++ b/pages/api/subgroups/index.js
@@ -30,8 +30,23 @@ export default async function handler(req, res) {
           },
         },
         orderBy: { user_sort: 'asc' },
+        include: {
+          _count: {
+            select: {
+              entries: {
+                where: { archived: false },
+              },
+            },
+          },
+        },
       });
-      return res.status(200).json(subgroups);
+
+      const withCounts = subgroups.map(({ _count, ...sg }) => ({
+        ...sg,
+        entryCount: _count?.entries ?? 0,
+      }));
+
+      return res.status(200).json(withCounts);
     } catch (error) {
       console.error('GET /api/subgroups error', error);
       return res.status(500).json({ error: 'Failed to fetch subgroups' });

--- a/src/components/Desk/DeskSurface.jsx
+++ b/src/components/Desk/DeskSurface.jsx
@@ -24,10 +24,11 @@ import {
   createEditEntryHandler,
 } from '@/utils/actionHandlers';
 
-function updateTreeData(list, key, children) {
+function updateTreeData(list, key, children, extra = {}) {
   return list.map((node) => {
-    if (node.key === key) return { ...node, children };
-    if (node.children) return { ...node, children: updateTreeData(node.children, key, children) };
+    if (node.key === key) return { ...node, ...extra, children };
+    if (node.children)
+      return { ...node, children: updateTreeData(node.children, key, children, extra) };
     return node;
   });
 }
@@ -238,6 +239,7 @@ export default function DeskSurface({
                 key: sg.id,
                 type: 'subgroup',
                 groupId: node.key,
+                entryCount: sg.entryCount ?? 0,
               }))
             )
           );
@@ -249,9 +251,8 @@ export default function DeskSurface({
       return fetch(`/api/entries?subgroupId=${node.key}`)
         .then((res) => (res.ok ? res.json() : []))
         .then((entries) => {
-          const filtered = showArch
-            ? entries
-            : entries.filter((e) => !e.archived);
+          const nonArchived = entries.filter((e) => !e.archived);
+          const filtered = showArch ? entries : nonArchived;
           setTreeData((origin) =>
             updateTreeData(
               origin,
@@ -266,7 +267,8 @@ export default function DeskSurface({
                 type: 'entry',
                 subgroupId: node.key,
                 groupId: node.groupId,
-              }))
+              })),
+              { entryCount: nonArchived.length }
             )
           );
         })
@@ -280,7 +282,8 @@ export default function DeskSurface({
     fetch(`/api/entries?subgroupId=${subgroupId}`)
       .then((res) => (res.ok ? res.json() : []))
       .then((entries) => {
-        const filtered = showArch ? entries : entries.filter((e) => !e.archived);
+        const nonArchived = entries.filter((e) => !e.archived);
+        const filtered = showArch ? entries : nonArchived;
         setTreeData((origin) =>
           updateTreeData(
             origin,
@@ -295,7 +298,8 @@ export default function DeskSurface({
               type: 'entry',
               subgroupId,
               groupId,
-            }))
+            })),
+            { entryCount: nonArchived.length }
           )
         );
       })
@@ -370,6 +374,7 @@ export default function DeskSurface({
                     key: sg.id,
                     type: 'subgroup',
                     groupId: parentId,
+                    entryCount: sg.entryCount ?? 0,
                   }))
                 )
               );

--- a/src/components/Tree/NotebookTree.jsx
+++ b/src/components/Tree/NotebookTree.jsx
@@ -334,9 +334,17 @@ export default function NotebookTree({
         // remove entry from old location
         for (const g of newGroups) {
           for (const s of g.children) {
-            s.children = (s.children || []).filter(
+            const newChildren = (s.children || []).filter(
               (e) => e.id !== updated.id && e.key !== updated.id
             );
+            if (newChildren.length !== (s.children || []).length) {
+              if (typeof s.entryCount === 'number') {
+                s.entryCount = Math.max(0, s.entryCount - 1);
+              } else {
+                s.entryCount = newChildren.filter((e) => !e.archived).length;
+              }
+            }
+            s.children = newChildren;
           }
         }
 
@@ -353,6 +361,10 @@ export default function NotebookTree({
               title: updated.title,
               snippet: updated.content?.slice(0, 100) || updated.snippet || '',
             });
+            targetSub.entryCount =
+              typeof targetSub.entryCount === 'number'
+                ? targetSub.entryCount + 1
+                : targetSub.children.filter((e) => !e.archived).length;
           }
         }
 
@@ -432,7 +444,9 @@ export default function NotebookTree({
                         openGroupId !== group.key ||
                         openSubgroupId !== null;
                       const nonArchivedCount =
-                        sub.children?.filter((e) => !e.archived).length || 0;
+                        typeof sub.entryCount === 'number'
+                          ? sub.entryCount
+                          : sub.children?.filter((e) => !e.archived).length || 0;
                       return (
                         <SubgroupCard
                           key={sub.key}

--- a/src/utils/actionHandlers.js
+++ b/src/utils/actionHandlers.js
@@ -60,11 +60,16 @@ export const createEntryDeleteHandler = ({ setTreeData, setOpenEntryId }) => (en
         ...g,
         children: g.children?.map((s) => {
           if (s.key !== entry.subgroupId) return s;
+          const newChildren = (s.children || []).filter(
+            (e) => e.key !== entry.key && e.id !== entry.id
+          );
           return {
             ...s,
-            children: (s.children || []).filter(
-              (e) => e.key !== entry.key && e.id !== entry.id
-            ),
+            children: newChildren,
+            entryCount:
+              typeof s.entryCount === 'number'
+                ? Math.max(0, s.entryCount - 1)
+                : newChildren.filter((e) => !e.archived).length,
           };
         }),
       };


### PR DESCRIPTION
## Summary
- include non-archived entry counts in `/api/subgroups`
- track and update `entryCount` in desk tree data
- show subgroup entry counts immediately on group expand

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c5985caf40832d84d730bce5c0ec5b