### PR TITLE
Add status column to Entry model

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
 - Entries may be archived instead of deleted. Archived entries are hidden by
   default but can be shown using the "Show Archived" toggle in the notebook
   controller. Archived items appear greyed out and can be restored later.
+- Entry workflow progress is tracked via a `status` field (`none`,
+  `in_progress`, or `complete`) to support future automation and filtering.
 - Tags: Meta data that relate to entries and are intended to be used to provide global search functionality
 - Pattern: The set of notebook aliases (Title, Description, Groups, Subgroups, Entries) that define the structure of a notebook
 - Model: A notebook instance with at least one group and one subgroup, representing data shaped by a pattern

--- a/prisma/migrations/20250815120000_add_entry_status/migration.sql
+++ b/prisma/migrations/20250815120000_add_entry_status/migration.sql
@@ -1,0 +1,2 @@
+-- CreateTable or alter statements
+ALTER TABLE "Entry" ADD COLUMN "status" TEXT NOT NULL DEFAULT 'none';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -94,6 +94,7 @@ model Entry {
   subgroupId   String
   tags         Tag[]      @relation("EntryTags") // Metadata tags
   archived     Boolean    @default(false)
+  status       String     @default("none")
   createdAt    DateTime   @default(now())
   updatedAt    DateTime   @updatedAt
 }

--- a/prisma/seed.mjs
+++ b/prisma/seed.mjs
@@ -122,18 +122,21 @@ async function main() {
       content: 'Content for Subgroup A',
       subgroupId: subgroups[0].id,
       tagIds: [tags[0].id, tags[1].id],
+      status: 'in_progress',
     },
     {
       title: 'Entry 1B',
       content: 'Content for Subgroup B',
       subgroupId: subgroups[1].id,
       tagIds: [tags[1].id, tags[2].id],
+      status: 'none',
     },
     {
       title: 'Entry 2C',
       content: 'Content for Subgroup C',
       subgroupId: subgroups[2].id,
       tagIds: [tags[2].id, tags[0].id],
+      status: 'complete',
     },
   ];
   for (const info of entryData) {
@@ -143,6 +146,7 @@ async function main() {
         content: info.content,
         userId: user.id,
         subgroupId: info.subgroupId,
+        status: info.status,
         tags: {
           connect: info.tagIds.map(id => ({ id })),
         },


### PR DESCRIPTION
## Summary
- add a status field to the Entry Prisma model with a default of "none"
- generate a migration and update the seed data to populate statuses for demo entries
- document the new Entry status field for contributors in the README

## Testing
- `DATABASE_URL="postgresql://postgres:postgres@localhost:5432/inmywords" npx prisma migrate dev --name add-entry-status` *(fails: cannot reach the local PostgreSQL server in the execution environment)*
- `npx prisma generate`
- `npm test` *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68d012d6fcd0832dab34cd2136e915d3