### PR TITLE
Add entry status tests and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@
 - Entries may be archived instead of deleted. Archived entries are hidden by
   default but can be shown using the "Show Archived" toggle in the notebook
   controller. Archived items appear greyed out and can be restored later.
-- Entry workflow progress is tracked via a `status` field (`none`,
-  `in_progress`, or `complete`) to support future automation and filtering.
+- Entry workflow progress is tracked via a `status` field to support future
+  automation and filtering. Entries start in the `none` state and can transition
+  to `in_progress` or `complete`. Completed entries render with a highlighted
+  status pill in the tree view so they stand out visually.
 - Tags: Meta data that relate to entries and are intended to be used to provide global search functionality
 - Pattern: The set of notebook aliases (Title, Description, Groups, Subgroups, Entries) that define the structure of a notebook
 - Model: A notebook instance with at least one group and one subgroup, representing data shaped by a pattern
@@ -125,6 +127,16 @@
 - tags
 - - [id].js
 - - index.js
+
+### Entry statuses
+
+- Default status: `none`
+- In progress: `in_progress`
+- Complete: `complete`
+
+The API validates that any `status` provided in POST/PUT requests for entries
+matches one of the above values. Invalid statuses return `400 Bad Request`
+errors, ensuring client code cannot persist unsupported workflow states.
 
 ## Development
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -19,3 +19,17 @@ This command runs ESLint with zero warnings allowed and then executes Jest tests
 - **Accessibility.** Query elements by accessible roles and names to mirror how users interact with the UI.
 
 See `src/components/Tree/NotebookTree.test.jsx` for an example of testing a dynamic component.
+
+## Manual QA checklist
+
+Use the following smoke test after deploying UI changes that affect entry
+statuses:
+
+1. Create a new entry and confirm the status pill shows "None" in the tree.
+2. Update the entry to `in_progress` and verify the pill text updates without
+   highlight styling.
+3. Update the entry to `complete` and confirm both the pill and card receive the
+   highlighted styling.
+4. Click the snippet area to ensure the entry editor still opens via `onEdit`.
+5. Attempt to save an entry with an invalid status via the API and verify the
+   response returns `400 Bad Request`.

--- a/pages/api/entries/status.test.js
+++ b/pages/api/entries/status.test.js
@@ -1,0 +1,225 @@
+/** @jest-environment node */
+
+import { DEFAULT_ENTRY_STATUS, ENTRY_STATUS_VALUES } from '@/constants/entryStatus';
+
+var mockEntryDelegate;
+var mockSubgroupDelegate;
+
+jest.mock('@prisma/client', () => {
+  mockEntryDelegate = {
+    findMany: jest.fn(),
+    count: jest.fn(),
+    create: jest.fn(),
+    findUnique: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  };
+
+  mockSubgroupDelegate = {
+    findUnique: jest.fn(),
+  };
+
+  return {
+    PrismaClient: jest.fn(() => ({
+      entry: mockEntryDelegate,
+      subgroup: mockSubgroupDelegate,
+    })),
+  };
+});
+
+jest.mock('next-auth', () => ({
+  __esModule: true,
+  default: jest.fn(() => jest.fn()),
+}));
+
+jest.mock('next-auth/next', () => ({
+  getServerSession: jest.fn(),
+}));
+
+import handlerIndex from './index';
+import handlerById from './[id]';
+import { getServerSession } from 'next-auth/next';
+
+const createRequest = ({ method = 'GET', body = {}, query = {} } = {}) => ({
+  method,
+  body,
+  query,
+  headers: {},
+  cookies: {},
+});
+
+const createResponse = () => {
+  const res = {
+    statusCode: 200,
+    headers: {},
+    jsonData: undefined,
+    textData: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(data) {
+      this.jsonData = data;
+      return this;
+    },
+    end(data) {
+      this.textData = data;
+      return this;
+    },
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+    _getJSON() {
+      return this.jsonData;
+    },
+    _getText() {
+      return this.textData;
+    },
+  };
+  return res;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  Object.values(mockEntryDelegate).forEach(mockFn => mockFn.mockReset());
+  Object.values(mockSubgroupDelegate).forEach(mockFn => mockFn.mockReset());
+  getServerSession.mockReset();
+  getServerSession.mockResolvedValue({ user: { id: 'user-123' } });
+});
+
+describe('POST /api/entries', () => {
+  it('accepts valid status values', async () => {
+    const subgroupId = 'sub-1';
+    mockSubgroupDelegate.findUnique.mockResolvedValue({
+      id: subgroupId,
+      group: { notebook: { userId: 'user-123' } },
+    });
+    mockEntryDelegate.count.mockResolvedValue(0);
+    const createdEntry = {
+      id: 'entry-1',
+      status: 'complete',
+    };
+    mockEntryDelegate.create.mockResolvedValue(createdEntry);
+
+    const req = createRequest({
+      method: 'POST',
+      body: {
+        title: 'New entry',
+        content: 'Body',
+        subgroupId,
+        status: 'complete',
+      },
+    });
+    const res = createResponse();
+
+    await handlerIndex(req, res);
+
+    expect(res.statusCode).toBe(201);
+    expect(mockEntryDelegate.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: 'complete' }),
+      })
+    );
+    expect(res._getJSON()).toEqual(createdEntry);
+  });
+
+  it('rejects an invalid status value', async () => {
+    const req = createRequest({
+      method: 'POST',
+      body: {
+        title: 'New entry',
+        content: 'Body',
+        subgroupId: 'sub-1',
+        status: 'invalid-status',
+      },
+    });
+    const res = createResponse();
+
+    await handlerIndex(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res._getJSON()).toEqual({ error: 'Invalid status' });
+    expect(mockEntryDelegate.create).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the default status when omitted', async () => {
+    const subgroupId = 'sub-1';
+    mockSubgroupDelegate.findUnique.mockResolvedValue({
+      id: subgroupId,
+      group: { notebook: { userId: 'user-123' } },
+    });
+    mockEntryDelegate.count.mockResolvedValue(1);
+    mockEntryDelegate.create.mockResolvedValue({ id: 'entry-2', status: DEFAULT_ENTRY_STATUS });
+
+    const req = createRequest({
+      method: 'POST',
+      body: {
+        title: 'New entry',
+        content: 'Body',
+        subgroupId,
+      },
+    });
+    const res = createResponse();
+
+    await handlerIndex(req, res);
+
+    expect(res.statusCode).toBe(201);
+    expect(mockEntryDelegate.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: DEFAULT_ENTRY_STATUS }),
+      })
+    );
+  });
+});
+
+describe('PUT /api/entries/[id]', () => {
+  it('updates the status when provided a valid value', async () => {
+    mockEntryDelegate.findUnique.mockResolvedValue({
+      id: 'entry-1',
+      userId: 'user-123',
+      tags: [],
+      subgroup: { group: {} },
+    });
+    const updatedEntry = { id: 'entry-1', status: ENTRY_STATUS_VALUES[1] };
+    mockEntryDelegate.update.mockResolvedValue(updatedEntry);
+
+    const req = createRequest({
+      method: 'PUT',
+      body: { status: ENTRY_STATUS_VALUES[1] },
+      query: { id: 'entry-1' },
+    });
+    const res = createResponse();
+
+    await handlerById(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(mockEntryDelegate.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: ENTRY_STATUS_VALUES[1] }),
+      })
+    );
+    expect(res._getJSON()).toEqual(updatedEntry);
+  });
+
+  it('rejects an invalid status on update', async () => {
+    mockEntryDelegate.findUnique.mockResolvedValue({
+      id: 'entry-1',
+      userId: 'user-123',
+      tags: [],
+      subgroup: { group: {} },
+    });
+
+    const req = createRequest({
+      method: 'PUT',
+      body: { status: 'invalid-status' },
+      query: { id: 'entry-1' },
+    });
+    const res = createResponse();
+
+    await handlerById(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res._getJSON()).toEqual({ error: 'Invalid status' });
+    expect(mockEntryDelegate.update).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/Tree/EntryCard.test.jsx
+++ b/src/components/Tree/EntryCard.test.jsx
@@ -2,13 +2,60 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { DndContext } from '@dnd-kit/core';
+import { DEFAULT_ENTRY_STATUS } from '@/constants/entryStatus';
+import styles from './EntryCard.module.css';
 import EntryCard from './EntryCard';
+
+const renderEntryCard = (entryOverrides = {}, props = {}) => {
+  const entry = {
+    id: '1',
+    title: 'Title',
+    snippet: 'Snippet text',
+    status: DEFAULT_ENTRY_STATUS,
+    ...entryOverrides,
+  };
+
+  return render(
+    <DndContext>
+      <EntryCard id={entry.id} entry={entry} isOpen onEdit={jest.fn()} {...props} />
+    </DndContext>
+  );
+};
+
+describe('EntryCard status pill', () => {
+  it('renders the status label with capitalization', () => {
+    renderEntryCard({ status: 'complete' });
+
+    expect(screen.getByLabelText('Status: Complete')).toHaveTextContent('Complete');
+  });
+
+  it.each`
+    status          | highlighted
+    ${'complete'}   | ${true}
+    ${'COMPLETE'}   | ${true}
+    ${'in_progress'}| ${false}
+    ${'none'}       | ${false}
+  `('applies highlight styling for status "$status" -> $highlighted', ({ status, highlighted }) => {
+    renderEntryCard({ status });
+
+    const card = screen.getByRole('button', { name: /title/i });
+    const statusPill = screen.getByLabelText(/status:/i);
+
+    if (highlighted) {
+      expect(card).toHaveClass(styles.highlighted);
+      expect(statusPill).toHaveClass(styles.statusHighlighted);
+    } else {
+      expect(card).not.toHaveClass(styles.highlighted);
+      expect(statusPill).not.toHaveClass(styles.statusHighlighted);
+    }
+  });
+});
 
 describe('EntryCard snippet interactions', () => {
   it('calls onEdit when snippet is clicked', async () => {
     const user = userEvent.setup();
     const onEdit = jest.fn();
-    const entry = { id: '1', title: 'Title', snippet: 'Snippet text' };
+    const entry = { id: '1', title: 'Title', snippet: 'Snippet text', status: 'complete' };
 
     render(
       <DndContext>


### PR DESCRIPTION
## Summary
- expand EntryCard unit tests to cover status pill rendering and highlight styling while ensuring snippet clicks still trigger edits
- add API integration tests for POST/PUT entry status validation, including defaulting and error handling
- document the entry status lifecycle in the README and add manual QA steps for verifying status behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d022cb171c832da4fb7199cf0069e7