### PR TITLE
Centralize Prisma client usage across API modules

### DIFF
--- a/__tests__/api/prismaClient.test.js
+++ b/__tests__/api/prismaClient.test.js
@@ -1,0 +1,52 @@
+/** @jest-environment node */
+
+const prismaInstances = [];
+
+jest.mock('@prisma/client', () => {
+  const PrismaClient = jest.fn(() => {
+    const instance = {
+      id: Symbol('mock-prisma'),
+      $disconnect: jest.fn().mockResolvedValue(undefined),
+    };
+    prismaInstances.push(instance);
+    return instance;
+  });
+
+  return { PrismaClient };
+});
+
+describe('prismaClient helper', () => {
+  afterEach(async () => {
+    jest.resetModules();
+    if (globalThis.__prismaClient?.$disconnect) {
+      await globalThis.__prismaClient.$disconnect();
+    }
+    delete globalThis.__prismaClient;
+    prismaInstances.length = 0;
+  });
+
+  it('returns the same instance across isolated imports', async () => {
+    jest.resetModules();
+    const firstModule = await import('../../src/api/prismaClient.js');
+    const first = firstModule.default;
+
+    jest.resetModules();
+    const secondModule = await import('../../src/api/prismaClient.js');
+    const second = secondModule.default;
+
+    expect(second).toBe(first);
+    expect(prismaInstances).toHaveLength(1);
+  });
+
+  it('disconnectPrisma disconnects and clears the cached instance', async () => {
+    jest.resetModules();
+    const module = await import('../../src/api/prismaClient.js');
+    const { default: prisma, disconnectPrisma } = module;
+
+    await disconnectPrisma();
+
+    expect(prisma.$disconnect).toHaveBeenCalledTimes(1);
+    expect(globalThis.__prismaClient).toBeUndefined();
+    expect(prismaInstances).toHaveLength(1);
+  });
+});

--- a/docs/backend/README.md
+++ b/docs/backend/README.md
@@ -1,0 +1,32 @@
+# Backend Developer Guide
+
+## Shared Prisma Client
+
+All API routes, auth handlers, and backend utilities must import the singleton Prisma client from `@/api/prismaClient` instead of constructing their own `PrismaClient` instances. This module wraps the generated client with a `globalThis` guard so hot reloading in development and module re-evaluation in serverless runtimes reuse the same connection.
+
+```js
+import prisma from '@/api/prismaClient';
+```
+
+### Script Lifecycle Etiquette
+
+Long-running scripts (e.g., `prisma/seed.mjs`) should import the same helper and call the exported `disconnectPrisma` function in a `finally` block before exiting. This ensures Node processes release database connections cleanly and resets the cached client for follow-up runs.
+
+```js
+import prisma, { disconnectPrisma } from '@/api/prismaClient.js';
+
+async function main() {
+  // ... script logic that uses prisma ...
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await disconnectPrisma();
+  });
+```
+
+Avoid calling `new PrismaClient()` directly anywhere outside `src/api/prismaClient.js`. An ESLint rule enforces this convention to prevent accidental connection churn.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,7 @@ import { defineConfig, globalIgnores } from 'eslint/config'
 export default defineConfig([
   globalIgnores(['dist']),
   {
-    files: ['**/*.{js,jsx}'],
+    files: ['**/*.{js,jsx,mjs}'],
     extends: [
       js.configs.recommended,
       reactHooks.configs['recommended-latest'],
@@ -24,6 +24,20 @@ export default defineConfig([
     },
     rules: {
       'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: "NewExpression[callee.name='PrismaClient']",
+          message:
+            'Use the shared Prisma client helper from src/api/prismaClient.js instead of instantiating PrismaClient directly.',
+        },
+      ],
+    },
+  },
+  {
+    files: ['src/api/prismaClient.js'],
+    rules: {
+      'no-restricted-syntax': 'off',
     },
   },
   {

--- a/pages/api/account/index.js
+++ b/pages/api/account/index.js
@@ -2,11 +2,10 @@
 // pages/api/account/index.js
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';
-import { PrismaClient } from '@prisma/client';
 import bcrypt from 'bcryptjs';
 import Stripe from 'stripe';
+import prisma from '@/api/prismaClient';
 
-const prisma = new PrismaClient();
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
 
 export default async function handler(req, res) {

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -2,13 +2,11 @@
 // pages/api/auth/[...nextauth].js
 
 import NextAuth from 'next-auth';
-import { PrismaClient } from '@prisma/client';
 import { PrismaAdapter } from '@next-auth/prisma-adapter';
 import CredentialsProvider from 'next-auth/providers/credentials';
 import GoogleProvider from 'next-auth/providers/google';
 import bcrypt from 'bcryptjs';
-
-const prisma = new PrismaClient();
+import prisma from '@/api/prismaClient';
 
 export const authOptions = {
   adapter: PrismaAdapter(prisma),

--- a/pages/api/entries/[id].js
+++ b/pages/api/entries/[id].js
@@ -1,10 +1,8 @@
 // pages/api/entries/[id].js
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';
-import { PrismaClient } from '@prisma/client';
 import { ENTRY_STATUS_VALUES } from '@/constants/entryStatus';
-
-const prisma = new PrismaClient();
+import prisma from '@/api/prismaClient';
 
 export default async function handler(req, res) {
   // Authenticate user

--- a/pages/api/entries/index.js
+++ b/pages/api/entries/index.js
@@ -1,10 +1,8 @@
 // pages/api/entries/index.js
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';
-import { PrismaClient } from '@prisma/client';
 import { ENTRY_STATUS_VALUES, DEFAULT_ENTRY_STATUS } from '@/constants/entryStatus';
-
-const prisma = new PrismaClient();
+import prisma from '@/api/prismaClient';
 
 export default async function handler(req, res) {
   // Authenticate user

--- a/pages/api/entries/reorder.js
+++ b/pages/api/entries/reorder.js
@@ -1,8 +1,6 @@
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';
-import { PrismaClient } from '@prisma/client';
-
-const prisma = new PrismaClient();
+import prisma from '@/api/prismaClient';
 
 export default async function handler(req, res) {
   if (req.method !== 'PATCH') {

--- a/pages/api/groups/[id].js
+++ b/pages/api/groups/[id].js
@@ -1,9 +1,7 @@
 // pages/api/groups/[id].js
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';
-import { PrismaClient } from '@prisma/client';
-
-const prisma = new PrismaClient();
+import prisma from '@/api/prismaClient';
 
 export default async function handler(req, res) {
   // Authenticate user

--- a/pages/api/groups/index.js
+++ b/pages/api/groups/index.js
@@ -1,9 +1,7 @@
 // pages/api/groups/index.js
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';
-import { PrismaClient } from '@prisma/client';
-
-const prisma = new PrismaClient();
+import prisma from '@/api/prismaClient';
 
 export default async function handler(req, res) {
   // Authenticate user

--- a/pages/api/groups/reorder.js
+++ b/pages/api/groups/reorder.js
@@ -1,8 +1,6 @@
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';
-import { PrismaClient } from '@prisma/client';
-
-const prisma = new PrismaClient();
+import prisma from '@/api/prismaClient';
 
 export default async function handler(req, res) {
   if (req.method !== 'PATCH') {

--- a/pages/api/notebooks/[id].js
+++ b/pages/api/notebooks/[id].js
@@ -1,8 +1,6 @@
-import { PrismaClient } from '@prisma/client';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';
-
-const prisma = new PrismaClient();
+import prisma from '@/api/prismaClient';
 
 export default async function handler(req, res) {
   const session = await getServerSession(req, res, authOptions);

--- a/pages/api/notebooks/[id]/tree.js
+++ b/pages/api/notebooks/[id]/tree.js
@@ -2,9 +2,7 @@
 
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../../auth/[...nextauth]';
-import { PrismaClient } from '@prisma/client';
-
-const prisma = new PrismaClient();
+import prisma from '@/api/prismaClient';
 
 export default async function handler(req, res) {
   // Only GET is allowed

--- a/pages/api/notebooks/index.js
+++ b/pages/api/notebooks/index.js
@@ -1,10 +1,8 @@
 // pages/api/notebooks/index.js
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "../auth/[...nextauth]";
-import { PrismaClient } from "@prisma/client";
 import { DEFAULT_ENTRY_STATUS, ENTRY_STATUS_VALUES } from "@/constants/entryStatus";
-
-const prisma = new PrismaClient();
+import prisma from "@/api/prismaClient";
 
 export default async function handler(req, res) {
   const session = await getServerSession(req, res, authOptions);

--- a/pages/api/precursors/[id].js
+++ b/pages/api/precursors/[id].js
@@ -1,8 +1,6 @@
-import { PrismaClient } from '@prisma/client';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';
-
-const prisma = new PrismaClient();
+import prisma from '@/api/prismaClient';
 
 export default async function handler(req, res) {
   const session = await getServerSession(req, res, authOptions);

--- a/pages/api/precursors/index.js
+++ b/pages/api/precursors/index.js
@@ -1,8 +1,6 @@
-import { PrismaClient } from '@prisma/client';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';
-
-const prisma = new PrismaClient();
+import prisma from '@/api/prismaClient';
 
 export default async function handler(req, res) {
   const session = await getServerSession(req, res, authOptions);

--- a/pages/api/stripe/webhook.js
+++ b/pages/api/stripe/webhook.js
@@ -1,7 +1,7 @@
 /* eslint-env node */
 
 import Stripe from 'stripe';
-import { PrismaClient } from '@prisma/client';
+import prisma from '@/api/prismaClient';
 
 export const config = {
   api: {
@@ -10,7 +10,6 @@ export const config = {
 };
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
-const prisma = new PrismaClient();
 
 const PRICE_TO_PLAN = {
   [process.env.STRIPE_PRICE_STANDARD]: 'standard',

--- a/pages/api/subgroups/[id].js
+++ b/pages/api/subgroups/[id].js
@@ -1,9 +1,7 @@
 // pages/api/subgroups/[id].js
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';
-import { PrismaClient } from '@prisma/client';
-
-const prisma = new PrismaClient();
+import prisma from '@/api/prismaClient';
 
 export default async function handler(req, res) {
   // Authenticate user

--- a/pages/api/subgroups/index.js
+++ b/pages/api/subgroups/index.js
@@ -1,9 +1,7 @@
 // pages/api/subgroups/index.js
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';
-import { PrismaClient } from '@prisma/client';
-
-const prisma = new PrismaClient();
+import prisma from '@/api/prismaClient';
 
 export default async function handler(req, res) {
   // Authenticate user

--- a/pages/api/subgroups/reorder.js
+++ b/pages/api/subgroups/reorder.js
@@ -1,8 +1,6 @@
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';
-import { PrismaClient } from '@prisma/client';
-
-const prisma = new PrismaClient();
+import prisma from '@/api/prismaClient';
 
 export default async function handler(req, res) {
   if (req.method !== 'PATCH') {

--- a/pages/api/tags/[id].js
+++ b/pages/api/tags/[id].js
@@ -1,8 +1,6 @@
-import { PrismaClient } from '@prisma/client';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';
-
-const prisma = new PrismaClient();
+import prisma from '@/api/prismaClient';
 
 export default async function handler(req, res) {
   // Authenticate

--- a/pages/api/tags/index.js
+++ b/pages/api/tags/index.js
@@ -1,12 +1,8 @@
 // src/pages/api/tags/index.js
 
-import { PrismaClient } from '@prisma/client';
 import { authOptions } from "../auth/[...nextauth]"; // Ensure this path is correct
 import { getServerSession } from 'next-auth/next';
-
-
-
-const prisma = new PrismaClient();
+import prisma from '@/api/prismaClient';
 
 export default async function handler(req, res) {
   // Authenticate user

--- a/prisma/seed.mjs
+++ b/prisma/seed.mjs
@@ -1,9 +1,7 @@
-import { PrismaClient } from '@prisma/client';
 import { readFileSync } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-
-const prisma = new PrismaClient();
+import prisma, { disconnectPrisma } from '../src/api/prismaClient.js';
 
 async function main() {
   // 1. Upsert demo user with fixed UUID
@@ -158,10 +156,10 @@ async function main() {
 }
 
 main()
-  .catch((e) => {
-    console.error(e);
-    process.exit(1);
+  .catch((error) => {
+    console.error('Seed failed', error);
+    process.exitCode = 1;
   })
   .finally(async () => {
-    await prisma.$disconnect();
+    await disconnectPrisma();
   });

--- a/src/api/prismaClient.js
+++ b/src/api/prismaClient.js
@@ -1,0 +1,16 @@
+import { PrismaClient } from '@prisma/client';
+
+const globalForPrisma = globalThis;
+
+const prisma = globalForPrisma.__prismaClient ?? new PrismaClient();
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForPrisma.__prismaClient = prisma;
+}
+
+export default prisma;
+
+export async function disconnectPrisma() {
+  await prisma.$disconnect();
+  delete globalForPrisma.__prismaClient;
+}


### PR DESCRIPTION
## Summary
- add a shared `src/api/prismaClient.js` module that caches the Prisma client and exposes a disconnect helper for scripts
- update API routes, NextAuth, and the seed script to import the shared client and enforce the pattern with an ESLint rule and unit test
- document the helper usage and script etiquette in backend docs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d702044270832d9634994494c1c5e3