### PR TITLE
Refactor notebook tree API and add performance coverage

### DIFF
--- a/__tests__/api/notebookTree.performance.test.js
+++ b/__tests__/api/notebookTree.performance.test.js
@@ -1,0 +1,329 @@
+/** @jest-environment node */
+
+import http from 'http';
+import supertest from 'supertest';
+import { apiResolver } from 'next/dist/server/api-utils/node/api-resolver';
+
+import treeHandler from '../../pages/api/notebooks/[id]/tree';
+import groupsHandler from '../../pages/api/groups/index';
+import subgroupsHandler from '../../pages/api/subgroups/index';
+import entriesHandler from '../../pages/api/entries/index';
+import prisma from '../../src/api/prismaClient';
+import { getServerSession } from 'next-auth/next';
+import {
+  notebook,
+  groups,
+  subgroupsByGroup,
+  entriesBySubgroup,
+  clone,
+  getGroupById,
+  getSubgroupById,
+} from '../../tests/fixtures/notebookTree';
+
+jest.mock('next-auth/next', () => ({
+  getServerSession: jest.fn(),
+}));
+
+jest.mock('next-auth', () => ({
+  __esModule: true,
+  default: jest.fn(() => jest.fn()),
+}));
+
+jest.mock('../../src/api/prismaClient', () => ({
+  notebook: {
+    findFirst: jest.fn(),
+    findUnique: jest.fn(),
+  },
+  group: {
+    count: jest.fn(),
+    findMany: jest.fn(),
+  },
+  subgroup: {
+    count: jest.fn(),
+    findMany: jest.fn(),
+  },
+  entry: {
+    count: jest.fn(),
+    findMany: jest.fn(),
+    groupBy: jest.fn(),
+  },
+}));
+
+const previewProps = {
+  previewModeId: 'test-id',
+  previewModeSigningKey: 'test-signing-key-test-signing-key',
+  previewModeEncryptionKey: 'test-encryption-key-test-encryption-key',
+};
+
+function createTestClient(apiHandler) {
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url, 'http://localhost');
+    const query = Object.fromEntries(url.searchParams.entries());
+    const parts = url.pathname.split('/').filter(Boolean);
+    if (parts[0] === 'api' && parts[1] === 'notebooks' && parts.length >= 4) {
+      query.id = parts[2];
+    }
+    apiResolver(req, res, query, { default: apiHandler }, {}, previewProps, false);
+  });
+
+  return {
+    request: supertest(server),
+    close: () =>
+      new Promise(resolve => {
+        server.close(resolve);
+      }),
+  };
+}
+
+function resetPrismaMocks() {
+  Object.values(prisma).forEach(model => {
+    Object.values(model).forEach(fn => fn.mockReset());
+  });
+}
+
+function applyOrder(list, orderBy) {
+  if (!orderBy) return [...list];
+  const orders = Array.isArray(orderBy) ? orderBy : [orderBy];
+  return [...list].sort((a, b) => {
+    for (const order of orders) {
+      const [key, direction] = Object.entries(order)[0];
+      const dir = direction === 'desc' ? -1 : 1;
+      if (a[key] < b[key]) return -1 * dir;
+      if (a[key] > b[key]) return 1 * dir;
+    }
+    return 0;
+  });
+}
+
+function applyCursor(list, cursor, skip = 0) {
+  if (!cursor) {
+    return skip ? list.slice(skip) : [...list];
+  }
+  const cursorId = cursor.id ?? cursor;
+  const index = list.findIndex(item => item.id === cursorId);
+  if (index === -1) return [];
+  const start = index + (skip ?? 0);
+  return list.slice(start);
+}
+
+function applyTake(list, take) {
+  if (!take) return [...list];
+  return list.slice(0, take);
+}
+
+function filterEntries(list, where = {}) {
+  return list.filter(entry => {
+    if (where.subgroupId && entry.subgroupId !== where.subgroupId) return false;
+    if (where.userId && entry.userId !== where.userId) return false;
+    if (where.archived === false && entry.archived) return false;
+    if (where.archived === true && !entry.archived) return false;
+    if (where.subgroupId?.in && !where.subgroupId.in.includes(entry.subgroupId)) return false;
+    return true;
+  });
+}
+
+function applySelect(record, select) {
+  if (!select) {
+    return clone(record);
+  }
+  const result = {};
+  Object.entries(select).forEach(([key, config]) => {
+    if (config === true) {
+      if (record[key] === undefined) {
+        result[key] = undefined;
+      } else {
+        result[key] = clone(record[key]);
+      }
+    } else if (config && typeof config === 'object') {
+      if (key === '_count') {
+        result._count = {};
+        Object.keys(config.select || {}).forEach(countKey => {
+          if (countKey === 'subgroups') {
+            result._count.subgroups = (subgroupsByGroup[record.id] || []).length;
+          }
+          if (countKey === 'entries') {
+            const subgroups = Object.values(subgroupsByGroup)
+              .flat()
+              .filter(subgroup => subgroup.groupId === record.id);
+            const totalEntries = subgroups.reduce(
+              (total, subgroup) => total + (entriesBySubgroup[subgroup.id]?.length || 0),
+              0,
+            );
+            result._count.entries = totalEntries;
+          }
+        });
+      } else if (key === 'subgroups') {
+        const { select: subSelect, orderBy, cursor, skip, take } = config;
+        const raw = (subgroupsByGroup[record.id] || []).map(clone);
+        const ordered = applyOrder(raw, orderBy);
+        const afterCursor = applyCursor(ordered, cursor, skip);
+        const sliced = applyTake(afterCursor, take);
+        result.subgroups = sliced.map(item => applySelect(item, subSelect));
+      } else if (key === 'entries') {
+        const { select: entrySelect, orderBy, cursor, skip, take, where } = config;
+        const raw = filterEntries(entriesBySubgroup[record.id] || [], where).map(clone);
+        const ordered = applyOrder(raw, orderBy);
+        const afterCursor = applyCursor(ordered, cursor, skip);
+        const sliced = applyTake(afterCursor, take);
+        result.entries = sliced.map(item => applySelect(item, entrySelect));
+      } else if (key === 'tags') {
+        const tagSelect = config.select || {};
+        result.tags = (record.tags || []).map(tag => applySelect(tag, tagSelect));
+      } else if (key === 'group') {
+        const group = getGroupById(record.groupId);
+        if (group) {
+          result.group = applySelect(group, config.select || {});
+        }
+      } else if (key === 'subgroup') {
+        const subgroup = getSubgroupById(record.subgroupId);
+        if (subgroup) {
+          result.subgroup = applySelect(subgroup, config.select || {});
+        }
+      }
+    }
+  });
+  return result;
+}
+
+function setupMockPrisma() {
+  prisma.notebook.findFirst.mockImplementation(async ({ where, select }) => {
+    if (where.id === notebook.id && where.userId === notebook.userId) {
+      return applySelect(notebook, select);
+    }
+    return null;
+  });
+
+  prisma.notebook.findUnique.mockImplementation(async ({ where, select }) => {
+    if (where.id === notebook.id) {
+      return applySelect(notebook, select);
+    }
+    return null;
+  });
+
+  prisma.group.count.mockImplementation(async ({ where }) => {
+    return groups.filter(group => group.notebookId === where.notebookId).length;
+  });
+
+  prisma.group.findMany.mockImplementation(async args => {
+    const { where, orderBy, take, cursor, skip, select } = args;
+    let list = groups.filter(group => group.notebookId === where.notebookId).map(clone);
+    list = applyOrder(list, orderBy);
+    list = applyCursor(list, cursor, skip);
+    list = applyTake(list, take);
+    if (select) {
+      return list.map(item => applySelect(item, select));
+    }
+    return list;
+  });
+
+  prisma.subgroup.count.mockImplementation(async ({ where }) => {
+    return (subgroupsByGroup[where.groupId] || []).length;
+  });
+
+  prisma.subgroup.findMany.mockImplementation(async args => {
+    const { where, orderBy, take, cursor, skip, select } = args;
+    let list = (subgroupsByGroup[where.groupId] || []).map(clone);
+    list = applyOrder(list, orderBy);
+    list = applyCursor(list, cursor, skip);
+    list = applyTake(list, take);
+    if (select) {
+      return list.map(item => applySelect(item, select));
+    }
+    return list;
+  });
+
+  prisma.entry.count.mockImplementation(async ({ where }) => {
+    const list = filterEntries(
+      Object.values(entriesBySubgroup).flat(),
+      where,
+    );
+    return list.length;
+  });
+
+  prisma.entry.findMany.mockImplementation(async args => {
+    const { where, orderBy, take, cursor, skip, select } = args;
+    let list = filterEntries(Object.values(entriesBySubgroup).flat(), where).map(clone);
+    list = applyOrder(list, orderBy);
+    list = applyCursor(list, cursor, skip);
+    list = applyTake(list, take);
+    if (select) {
+      return list.map(item => applySelect(item, select));
+    }
+    return list;
+  });
+
+  prisma.entry.groupBy.mockImplementation(async ({ where }) => {
+    const filtered = filterEntries(Object.values(entriesBySubgroup).flat(), where);
+    const map = new Map();
+    filtered.forEach(entry => {
+      map.set(entry.subgroupId, (map.get(entry.subgroupId) || 0) + 1);
+    });
+    return Array.from(map.entries()).map(([subgroupId, count]) => ({
+      subgroupId,
+      _count: { _all: count },
+    }));
+  });
+}
+
+beforeEach(() => {
+  getServerSession.mockResolvedValue({ user: { id: notebook.userId } });
+  resetPrismaMocks();
+  setupMockPrisma();
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('Notebook tree endpoint', () => {
+  it('returns combined notebook tree with nested pagination metadata', async () => {
+    const { request, close } = createTestClient(treeHandler);
+    const response = await request.get(
+      '/api/notebooks/nb1/tree?include=subgroups,entries&subgroups.for=g1&entries.for=sg1',
+    );
+    await close();
+
+    expect(response.status).toBe(200);
+    expect(response.body.notebook.id).toBe('nb1');
+    expect(response.body.groups.data).toHaveLength(2);
+
+    const [firstGroup, secondGroup] = response.body.groups.data;
+    expect(firstGroup.subgroups.data).toHaveLength(2);
+    expect(firstGroup.subgroups.meta.nextCursor).toBeUndefined();
+    expect(firstGroup.subgroups.data[0].entries.data).toHaveLength(2);
+    expect(firstGroup.subgroups.data[0].entries.meta.includeArchived).toBe(false);
+    expect(secondGroup.subgroups.data).toHaveLength(0);
+    expect(secondGroup.subgroups.meta.links.next).toContain('subgroups.for=g2');
+  });
+
+  it('reduces round trips and payload size compared to legacy flow', async () => {
+    const runRequest = async (handler, path) => {
+      const { request, close } = createTestClient(handler);
+      const result = await request.get(path);
+      await close();
+      return result;
+    };
+
+    const legacyResponses = [];
+    legacyResponses.push(await runRequest(groupsHandler, '/api/groups?notebookId=nb1'));
+    legacyResponses.push(await runRequest(subgroupsHandler, '/api/subgroups?groupId=g1'));
+    legacyResponses.push(await runRequest(entriesHandler, '/api/entries?subgroupId=sg1'));
+
+    const newResponse = await runRequest(
+      treeHandler,
+      '/api/notebooks/nb1/tree?include=subgroups,entries&subgroups.for=g1&entries.for=sg1',
+    );
+
+    expect(newResponse.status).toBe(200);
+    legacyResponses.forEach(res => expect(res.status).toBe(200));
+
+    const legacyPayload = legacyResponses.reduce(
+      (size, res) => size + JSON.stringify(res.body).length,
+      0,
+    );
+    const newPayload = JSON.stringify(newResponse.body).length;
+
+    expect(legacyResponses.length).toBe(3);
+    expect(newPayload).toBeLessThan(legacyPayload);
+  });
+});

--- a/docs/api/notebook-tree.md
+++ b/docs/api/notebook-tree.md
@@ -1,0 +1,142 @@
+# Notebook Tree API
+
+The `GET /api/notebooks/{id}/tree` endpoint returns a hierarchical view of a notebook, optionally including pre-fetched subgroups and entries. It combines data that previously required multiple round-trips (`/api/groups`, `/api/subgroups`, and `/api/entries`).
+
+The response is structured as a notebook envelope with paginated collections for each level. Nested collections surface pagination hooks and `next` URLs that target the same endpoint with scoped parameters, so clients can fetch additional slices without falling back to the legacy endpoints.
+
+## Query Parameters
+
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `groups.take` | integer | 20 | Page size for top-level groups (1-100). |
+| `groups.skip` | integer | — | Offset for classic pagination. Mutually exclusive with `groups.cursor`. |
+| `groups.cursor` | string | — | Cursor returned from a previous page. Mutually exclusive with `groups.skip`. |
+| `include` | comma-delimited string | — | Nested resources to include. Supports `subgroups` and `entries`. Selecting `entries` implies `subgroups`. |
+| `subgroups.for` | comma-delimited string | — | Limits subgroup prefetching to specific group ids. When omitted, subgroups are hydrated for all groups in the current page. |
+| `subgroups.take` | integer | 10 | Page size for each subgroup collection (1-50). Applied per group. |
+| `subgroups.cursor` | comma-delimited key:value pairs | — | Cursors for subgroup pagination. Each entry uses the format `{groupId}:{cursor}`. |
+| `entries.for` | comma-delimited string | — | Limits entry prefetching to specific subgroup ids. Defaults to all subgroups returned in the response. Requires `include=entries`. |
+| `entries.take` | integer | 20 | Page size for each entry collection (1-100). Applied per subgroup. |
+| `entries.cursor` | comma-delimited key:value pairs | — | Cursors for entry pagination using `{subgroupId}:{cursor}` format. |
+| `entries.includeArchived` | boolean | `false` | When `true`, archived entries are included in entry collections and pagination metadata. |
+
+Invalid pagination combinations (e.g., mixing skip and cursor) produce a `400` response consistent with the shared pagination helpers.
+
+## Response
+
+```jsonc
+{
+  "notebook": {
+    "id": "nb1",
+    "title": "Field Notes",
+    "description": "Research notebook",
+    "user_notebook_tree": ["Group", "Subgroup", "Entry"],
+    "createdAt": "2024-01-01T00:00:00.000Z",
+    "updatedAt": "2024-01-03T12:00:00.000Z"
+  },
+  "groups": {
+    "data": [
+      {
+        "id": "g1",
+        "name": "Research",
+        "description": "Primary backlog",
+        "user_sort": 0,
+        "notebookId": "nb1",
+        "createdAt": "2024-01-01T00:00:00.000Z",
+        "updatedAt": "2024-01-02T00:00:00.000Z",
+        "subgroups": {
+          "data": [
+            {
+              "id": "sg1",
+              "name": "Articles",
+              "description": null,
+              "user_sort": 0,
+              "groupId": "g1",
+              "createdAt": "2024-01-01T00:00:00.000Z",
+              "updatedAt": "2024-01-02T00:00:00.000Z",
+              "entries": {
+                "data": [
+                  {
+                    "id": "e1",
+                    "title": "Protein research",
+                    "content": "<p>Findings…</p>",
+                    "status": "none",
+                    "archived": false,
+                    "user_sort": 0,
+                    "subgroupId": "sg1",
+                    "createdAt": "2024-01-01T00:00:00.000Z",
+                    "updatedAt": "2024-01-02T00:00:00.000Z",
+                    "tags": [
+                      { "id": "t1", "name": "Biology", "code": "bio" }
+                    ]
+                  }
+                ],
+                "meta": {
+                  "take": 20,
+                  "count": 1,
+                  "total": 4,
+                  "hasMore": true,
+                  "includeArchived": false,
+                  "cursor": null,
+                  "nextCursor": "e2",
+                  "links": {
+                    "next": "/api/notebooks/nb1/tree?include=entries&entries.for=sg1&entries.take=20&entries.cursor=sg1:e2&entries.includeArchived=false"
+                  }
+                }
+              }
+            }
+          ],
+          "meta": {
+            "take": 10,
+            "count": 1,
+            "total": 3,
+            "hasMore": true,
+            "cursor": null,
+            "nextCursor": "sg2",
+            "links": {
+              "next": "/api/notebooks/nb1/tree?include=subgroups&subgroups.for=g1&subgroups.take=10&subgroups.cursor=g1:sg2"
+            }
+          }
+        }
+      }
+    ],
+    "meta": {
+      "take": 20,
+      "count": 1,
+      "total": 8,
+      "hasMore": true,
+      "cursor": null,
+      "nextCursor": "g2",
+      "links": {
+        "next": "/api/notebooks/nb1/tree?groups.take=20&groups.cursor=g2&include=subgroups,entries"
+      }
+    }
+  }
+}
+```
+
+### Notebook payload
+
+The notebook envelope always includes the immutable notebook metadata so the client no longer needs to query `/api/notebooks/{id}` before rendering the tree.
+
+### Group objects
+
+Group records mirror the `GET /api/groups` projection. When `include=subgroups` is provided the `subgroups` key appears with its own `{ data, meta }` structure. Pagination metadata is normalized across levels (take, count, total, cursor, nextCursor, hasMore) and `links.next` points back to this endpoint with the parameters needed to fetch the next slice for the current group.
+
+### Subgroup objects
+
+Subgroup records match the default `GET /api/subgroups` selection. When `include=entries` is active each subgroup gains an `entries` object with `{ data, meta }`. Entry pagination metadata contains `includeArchived` to help clients preserve filters when requesting the next slice.
+
+If `include=entries` is omitted, `subgroups.meta` is still returned (with empty `data`) so the client can render pagination controls without making a secondary request.
+
+### Entry objects
+
+Entries are returned without the nested `subgroup`/`group` fan-out that `/api/entries` provides by default. Only the direct entry fields plus lightweight tag projections are included to minimize payload size. Clients can re-use the tree endpoint with targeted parameters whenever they need more entry pages or archived slices.
+
+## Error responses
+
+* `400` – Invalid pagination or projection options (mirrors shared helper errors).
+* `401` – Missing or invalid session.
+* `404` – Notebook not found or not owned by the requester.
+* `405` – Methods other than `GET` are rejected with an `Allow: GET` header.
+* `500` – Unexpected server error with a logged stack trace. A schema mismatch (e.g., missing `archived` column) surfaces the same migration hint as the legacy route.

--- a/docs/frontend-notebook-tree-loading.md
+++ b/docs/frontend-notebook-tree-loading.md
@@ -1,0 +1,60 @@
+# Notebook Tree Data Loading (Current State)
+
+This document captures how the existing client implements notebook tree loading and highlights redundant HTTP round-trips that informed the unified tree endpoint work.
+
+## Primary entry point
+
+* `pages/notebook-dev.js` renders `<DeskSurface />`, which contains all notebook tree orchestration logic.
+* `DeskSurface` lives at `src/components/Desk/DeskSurface.jsx` and manages notebook selection, tree state, and editor interactions.
+
+## Initial notebook restoration
+
+1. On mount `DeskSurface` reads `lastNotebookId` from `localStorage`.  
+2. If a notebook id exists the component issues `fetch('/api/notebooks/{id}')` to ensure ownership and load notebook metadata.  
+3. Once the notebook id is confirmed the component sets local state and triggers downstream data loading (groups, subgroups, entries).
+
+This initial metadata fetch is separate from any tree fetches, so the UI always makes **at least one** HTTP request before drawing the tree.
+
+## Group list loading (`fetchGroups`)
+
+* `fetchGroups` issues `GET /api/groups?notebookId={id}`.  
+* Response is normalized (`unwrapPayload`) and stored as top-level tree nodes.  
+* This occurs whenever the notebook id changes or a new group is created.
+
+Because this endpoint only returns the group shell, additional requests are required to populate sublevels.
+
+## Subgroup expansion (`loadData` / `reloadNode`)
+
+When a group node is expanded the component calls `loadData(node)`:
+
+1. For `group` nodes it issues `GET /api/subgroups?groupId={groupId}`.  
+2. Results are merged into the tree.  
+3. `reloadNode` repeats the same request after mutations to refresh cached data.
+
+Each group expansion therefore incurs a **dedicated** network round-trip, even if multiple groups are expanded in quick succession.
+
+## Entry expansion (`loadData` / `reloadEntries`)
+
+For `subgroup` nodes:
+
+1. `loadData` calls `GET /api/entries?subgroupId={subgroupId}`.
+2. Entries are filtered on the client to hide archived items unless the archived toggle is active.
+3. `reloadEntries` is invoked whenever entries mutate (save, archive, delete) and issues the same request again.
+
+Entries are loaded per subgroup, leading to a growing number of HTTP calls as the user explores deeper into the tree.
+
+## Archived toggle side-effect
+
+Toggling the "Show archived" switch iterates over all subgroups that currently have entry data and re-executes `reloadEntries`. This means a single UI interaction can trigger **N additional `/api/entries` requests** equal to the number of populated subgroups.
+
+## Summary of redundant round-trips
+
+| Interaction | Requests issued |
+| ----------- | ---------------- |
+| Restore last notebook | 1 × `/api/notebooks/{id}` |
+| Initial tree render | 1 × `/api/groups?notebookId=…` |
+| Expand each group | 1 × `/api/subgroups?groupId=…` per group |
+| Expand each subgroup | 1 × `/api/entries?subgroupId=…` per subgroup |
+| Toggle archived flag | 1 × `/api/entries?subgroupId=…` per populated subgroup |
+
+The lack of batching results in dozens of sequential HTTP round-trips for common workflows. The new combined tree endpoint is intended to prefetch these layers in a single request and surface pagination metadata so the client can fetch additional slices only when necessary.

--- a/pages/api/notebooks/[id]/tree.js
+++ b/pages/api/notebooks/[id]/tree.js
@@ -3,50 +3,486 @@
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../../auth/[...nextauth]';
 import prisma from '@/api/prismaClient';
+import { parsePaginationParams } from '@/api/pagination';
+
+const DEFAULT_GROUP_TAKE = 20;
+const DEFAULT_SUBGROUP_TAKE = 10;
+const DEFAULT_ENTRY_TAKE = 20;
+const MAX_SUBGROUP_TAKE = 50;
+
+function parseListParam(value) {
+  if (!value) return [];
+  if (Array.isArray(value)) {
+    return value.flatMap(parseListParam);
+  }
+  return value
+    .split(',')
+    .map(part => part.trim())
+    .filter(Boolean);
+}
+
+function parseCursorMap(value) {
+  const map = {};
+  parseListParam(value).forEach(entry => {
+    const [key, cursor] = entry.split(':');
+    if (key && cursor) {
+      map[key] = cursor;
+    }
+  });
+  return map;
+}
+
+function parseBooleanParam(value, defaultValue = false) {
+  if (value === undefined) return defaultValue;
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') {
+    if (value.toLowerCase() === 'true') return true;
+    if (value.toLowerCase() === 'false') return false;
+  }
+  throw new Error('Boolean query parameters must be "true" or "false".');
+}
+
+function stringifyParam(value) {
+  if (value === undefined) return undefined;
+  if (Array.isArray(value)) return value.join(',');
+  return value;
+}
+
+function buildGroupsNextLink({
+  notebookId,
+  take,
+  cursor,
+  include,
+  subgroupsFor,
+  subgroupsTake,
+  entriesFor,
+  entriesTake,
+  entriesIncludeArchived,
+}) {
+  if (!cursor) return null;
+  const params = new URLSearchParams();
+  params.set('groups.take', String(take));
+  params.set('groups.cursor', cursor);
+  if (include?.size) {
+    params.set('include', Array.from(include).join(','));
+  }
+  if (subgroupsFor) {
+    params.set('subgroups.for', subgroupsFor);
+  }
+  if (subgroupsTake) {
+    params.set('subgroups.take', String(subgroupsTake));
+  }
+  if (entriesFor) {
+    params.set('entries.for', entriesFor);
+  }
+  if (entriesTake) {
+    params.set('entries.take', String(entriesTake));
+  }
+  if (entriesIncludeArchived !== undefined) {
+    params.set('entries.includeArchived', entriesIncludeArchived ? 'true' : 'false');
+  }
+  return `/api/notebooks/${notebookId}/tree?${params.toString()}`;
+}
+
+function buildScopedNextLink({
+  notebookId,
+  include,
+  take,
+  cursor,
+  scope,
+  scopeId,
+  extra = {},
+  allowEmptyCursor = false,
+}) {
+  if (!allowEmptyCursor && !cursor) return null;
+  const params = new URLSearchParams();
+  if (include?.size) {
+    params.set('include', Array.from(include).join(','));
+  }
+  params.set(`${scope}.for`, scopeId);
+  params.set(`${scope}.take`, String(take));
+  if (cursor) {
+    params.set(`${scope}.cursor`, `${scopeId}:${cursor}`);
+  }
+  Object.entries(extra).forEach(([key, value]) => {
+    if (value === undefined || value === null) return;
+    params.set(key, String(value));
+  });
+  return `/api/notebooks/${notebookId}/tree?${params.toString()}`;
+}
 
 export default async function handler(req, res) {
-  // Only GET is allowed
   if (req.method !== 'GET') {
     res.setHeader('Allow', ['GET']);
     return res.status(405).end(`Method ${req.method} Not Allowed`);
   }
 
-  // Authenticate user
   const session = await getServerSession(req, res, authOptions);
   if (!session) {
     return res.status(401).json({ error: 'Unauthorized' });
   }
+
   const userId = session.user.id;
   const notebookId = req.query.id;
 
+  const includeRaw = req.query.include;
+  const includeSet = new Set(parseListParam(includeRaw));
+  const includeSubgroups = includeSet.has('subgroups') || includeSet.has('entries');
+  const includeEntries = includeSet.has('entries');
+
+  const subgroupsForRaw = stringifyParam(req.query['subgroups.for']);
+  const entriesForRaw = stringifyParam(req.query['entries.for']);
+
+  const subgroupCursorMap = parseCursorMap(req.query['subgroups.cursor']);
+  const entryCursorMap = parseCursorMap(req.query['entries.cursor']);
+
+  let groupsPagination;
+  let subgroupPagination;
+  let entryPagination;
+  let includeArchived;
+
   try {
-    // Fetch the notebook with nested groups, subgroups, and entries (including tags)
-    const notebook = await prisma.notebook.findUnique({
-      where: { id: notebookId },
-      include: {
-        groups: {
-          orderBy: { user_sort: 'asc' },
-          include: {
-            subgroups: {
-              orderBy: { user_sort: 'asc' },
-              include: {
-                entries: {
-                  include: { tags: true },
-                  orderBy: { user_sort: 'asc' }
-                }
-              }
-            }
-          }
-        }
-      }
+    groupsPagination = parsePaginationParams(
+      {
+        take: req.query['groups.take'],
+        skip: req.query['groups.skip'],
+        cursor: req.query['groups.cursor'],
+      },
+      { defaultTake: DEFAULT_GROUP_TAKE, maxTake: 100 },
+    );
+
+    subgroupPagination = parsePaginationParams(
+      {
+        take: req.query['subgroups.take'],
+      },
+      { defaultTake: DEFAULT_SUBGROUP_TAKE, maxTake: MAX_SUBGROUP_TAKE },
+    );
+
+    entryPagination = parsePaginationParams(
+      {
+        take: req.query['entries.take'],
+      },
+      { defaultTake: DEFAULT_ENTRY_TAKE, maxTake: 100 },
+    );
+
+    includeArchived = parseBooleanParam(req.query['entries.includeArchived'], false);
+  } catch (error) {
+    return res.status(400).json({ error: error.message });
+  }
+
+  const subgroupTargets = includeSubgroups
+    ? parseListParam(req.query['subgroups.for'])
+    : [];
+  const entryTargets = includeEntries ? parseListParam(req.query['entries.for']) : [];
+
+  try {
+    const notebook = await prisma.notebook.findFirst({
+      where: { id: notebookId, userId },
+      select: {
+        id: true,
+        title: true,
+        description: true,
+        user_notebook_tree: true,
+        createdAt: true,
+        updatedAt: true,
+      },
     });
 
-    // Verify existence and ownership
-    if (!notebook || notebook.userId !== userId) {
+    if (!notebook) {
       return res.status(404).json({ error: 'Notebook not found' });
     }
 
-    return res.status(200).json(notebook);
+    const whereGroups = {
+      notebookId,
+      notebook: { userId },
+    };
+
+    const [groupsTotal, rawGroups] = await Promise.all([
+      prisma.group.count({ where: whereGroups }),
+      prisma.group.findMany({
+        where: whereGroups,
+        orderBy: { user_sort: 'asc' },
+        take: groupsPagination.take + 1,
+        select: {
+          id: true,
+          name: true,
+          description: true,
+          user_sort: true,
+          notebookId: true,
+          createdAt: true,
+          updatedAt: true,
+          ...(includeSubgroups
+            ? {
+                _count: {
+                  select: { subgroups: true },
+                },
+              }
+            : {}),
+        },
+        ...(groupsPagination.cursor
+          ? { cursor: { id: groupsPagination.cursor }, skip: 1 }
+          : groupsPagination.skip !== undefined
+            ? { skip: groupsPagination.skip }
+            : {}),
+      }),
+    ]);
+
+    let nextGroupCursor = null;
+    if (rawGroups.length > groupsPagination.take) {
+      const nextRecord = rawGroups.pop();
+      nextGroupCursor = nextRecord?.id ?? null;
+    }
+
+    const groups = rawGroups.map(group => ({ ...group }));
+    const groupsData = groups.map(group => ({
+      id: group.id,
+      name: group.name,
+      description: group.description,
+      user_sort: group.user_sort,
+      notebookId: group.notebookId,
+      createdAt: group.createdAt,
+      updatedAt: group.updatedAt,
+    }));
+
+    const groupsMeta = {
+      take: groupsPagination.take,
+      count: groupsData.length,
+      total: groupsTotal,
+      hasMore: nextGroupCursor !== null
+        ? true
+        : groupsPagination.skip !== undefined
+          ? groupsPagination.skip + groupsData.length < groupsTotal
+          : groupsData.length < groupsTotal,
+    };
+
+    if (groupsPagination.skip !== undefined) {
+      groupsMeta.skip = groupsPagination.skip;
+    }
+    if (groupsPagination.cursor) {
+      groupsMeta.cursor = groupsPagination.cursor;
+    }
+    if (nextGroupCursor) {
+      groupsMeta.nextCursor = nextGroupCursor;
+    }
+    const groupsNextLink = buildGroupsNextLink({
+      notebookId,
+      take: groupsPagination.take,
+      cursor: nextGroupCursor,
+      include: includeSet,
+      subgroupsFor: subgroupsForRaw,
+      subgroupsTake: includeSubgroups ? subgroupPagination.take : undefined,
+      entriesFor: includeEntries ? entriesForRaw : undefined,
+      entriesTake: includeEntries ? entryPagination.take : undefined,
+      entriesIncludeArchived: includeEntries ? includeArchived : undefined,
+    });
+    if (groupsNextLink) {
+      groupsMeta.links = { next: groupsNextLink };
+    }
+
+    const groupIdToIndex = new Map(groupsData.map((group, index) => [group.id, index]));
+    const targetedGroupIds = includeSubgroups
+      ? (subgroupTargets.length
+          ? subgroupTargets.filter(id => groupIdToIndex.has(id))
+          : groupsData.map(group => group.id))
+      : [];
+
+    const subgroupDataById = new Map();
+    const subgroupBlocks = new Map();
+
+    if (targetedGroupIds.length) {
+      await Promise.all(
+        targetedGroupIds.map(async groupId => {
+          const cursor = subgroupCursorMap[groupId];
+          const subgroupWhere = {
+            groupId,
+          };
+          const [records, total] = await Promise.all([
+            prisma.subgroup.findMany({
+              where: subgroupWhere,
+              orderBy: { user_sort: 'asc' },
+              take: subgroupPagination.take + 1,
+              select: {
+                id: true,
+                name: true,
+                description: true,
+                user_sort: true,
+                groupId: true,
+                createdAt: true,
+                updatedAt: true,
+              },
+              ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+            }),
+            prisma.subgroup.count({ where: subgroupWhere }),
+          ]);
+
+          let nextCursor = null;
+          if (records.length > subgroupPagination.take) {
+            const nextRecord = records.pop();
+            nextCursor = nextRecord?.id ?? null;
+          }
+
+          const data = records.map(subgroup => ({ ...subgroup }));
+          data.forEach(subgroup => subgroupDataById.set(subgroup.id, subgroup));
+
+          const meta = {
+            take: subgroupPagination.take,
+            count: data.length,
+            total,
+            hasMore: nextCursor !== null
+              ? true
+              : data.length < total,
+          };
+          if (cursor) {
+            meta.cursor = cursor;
+          }
+          if (nextCursor) {
+            meta.nextCursor = nextCursor;
+          }
+          const nextLink = buildScopedNextLink({
+            notebookId,
+            include: includeSet,
+            take: subgroupPagination.take,
+            cursor: nextCursor,
+            scope: 'subgroups',
+            scopeId: groupId,
+          });
+          if (nextLink) {
+            meta.links = { next: nextLink };
+          }
+
+          subgroupBlocks.set(groupId, { data, meta });
+        }),
+      );
+    }
+
+    const entryTargetIds = includeEntries
+      ? (entryTargets.length ? entryTargets : Array.from(subgroupDataById.keys()))
+      : [];
+
+    if (entryTargetIds.length) {
+      await Promise.all(
+        entryTargetIds
+          .filter(subgroupId => subgroupDataById.has(subgroupId))
+          .map(async subgroupId => {
+            const cursor = entryCursorMap[subgroupId];
+            const where = {
+              subgroupId,
+              userId,
+              ...(includeArchived ? {} : { archived: false }),
+            };
+            const [records, total] = await Promise.all([
+              prisma.entry.findMany({
+                where,
+                orderBy: { user_sort: 'asc' },
+                take: entryPagination.take + 1,
+                select: {
+                  id: true,
+                  title: true,
+                  content: true,
+                  status: true,
+                  archived: true,
+                  user_sort: true,
+                  subgroupId: true,
+                  createdAt: true,
+                  updatedAt: true,
+                  tags: {
+                    select: {
+                      id: true,
+                      name: true,
+                      code: true,
+                    },
+                    orderBy: { name: 'asc' },
+                  },
+                },
+                ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+              }),
+              prisma.entry.count({ where }),
+            ]);
+
+            let nextCursor = null;
+            if (records.length > entryPagination.take) {
+              const nextRecord = records.pop();
+              nextCursor = nextRecord?.id ?? null;
+            }
+
+            const data = records.map(entry => ({ ...entry }));
+            const meta = {
+              take: entryPagination.take,
+              count: data.length,
+              total,
+              hasMore: nextCursor !== null
+                ? true
+                : data.length < total,
+              includeArchived,
+            };
+            if (cursor) {
+              meta.cursor = cursor;
+            }
+            if (nextCursor) {
+              meta.nextCursor = nextCursor;
+            }
+            const nextLink = buildScopedNextLink({
+              notebookId,
+              include: includeSet,
+              take: entryPagination.take,
+              cursor: nextCursor,
+              scope: 'entries',
+              scopeId: subgroupId,
+              extra: {
+                'entries.includeArchived': includeArchived ? 'true' : 'false',
+              },
+            });
+            if (nextLink) {
+              meta.links = { next: nextLink };
+            }
+
+            const subgroup = subgroupDataById.get(subgroupId);
+            if (subgroup) {
+              subgroup.entries = { data, meta };
+            }
+          }),
+      );
+    }
+
+    if (includeSubgroups) {
+      groupsData.forEach(group => {
+        const block = subgroupBlocks.get(group.id);
+        if (block) {
+          group.subgroups = block;
+        } else {
+          const total = groups.find(item => item.id === group.id)?._count?.subgroups ?? 0;
+          const meta = {
+            take: subgroupPagination.take,
+            count: 0,
+            total,
+            hasMore: total > 0,
+          };
+          const nextLink = buildScopedNextLink({
+            notebookId,
+            include: includeSet,
+            take: subgroupPagination.take,
+            cursor: null,
+            scope: 'subgroups',
+            scopeId: group.id,
+            allowEmptyCursor: total > 0,
+          });
+          if (nextLink) {
+            meta.links = { next: nextLink };
+          }
+          group.subgroups = { data: [], meta };
+        }
+      });
+    }
+
+    const response = {
+      notebook,
+      groups: {
+        data: groupsData,
+        meta: groupsMeta,
+      },
+    };
+
+    return res.status(200).json(response);
   } catch (error) {
     if (error.message && error.message.includes('archived')) {
       console.error('Migration required: missing archived column', error);

--- a/tests/fixtures/notebookTree.js
+++ b/tests/fixtures/notebookTree.js
@@ -1,0 +1,158 @@
+export const notebook = {
+  id: 'nb1',
+  title: 'Field Notes',
+  description: 'Research notebook',
+  userId: 'user-123',
+  user_notebook_tree: ['Group', 'Subgroup', 'Entry'],
+  createdAt: new Date('2024-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2024-01-03T12:00:00.000Z'),
+};
+
+export const groups = [
+  {
+    id: 'g1',
+    name: 'Research',
+    description: 'Primary backlog',
+    user_sort: 0,
+    notebookId: notebook.id,
+    createdAt: new Date('2024-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2024-01-02T00:00:00.000Z'),
+  },
+  {
+    id: 'g2',
+    name: 'Archive',
+    description: null,
+    user_sort: 1,
+    notebookId: notebook.id,
+    createdAt: new Date('2024-01-04T00:00:00.000Z'),
+    updatedAt: new Date('2024-01-05T00:00:00.000Z'),
+  },
+];
+
+export const subgroupsByGroup = {
+  g1: [
+    {
+      id: 'sg1',
+      name: 'Articles',
+      description: null,
+      user_sort: 0,
+      groupId: 'g1',
+      createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2024-01-02T00:00:00.000Z'),
+    },
+    {
+      id: 'sg2',
+      name: 'Interviews',
+      description: 'Qualitative notes',
+      user_sort: 1,
+      groupId: 'g1',
+      createdAt: new Date('2024-01-02T00:00:00.000Z'),
+      updatedAt: new Date('2024-01-03T00:00:00.000Z'),
+    },
+  ],
+  g2: [
+    {
+      id: 'sg3',
+      name: 'Past Experiments',
+      description: null,
+      user_sort: 0,
+      groupId: 'g2',
+      createdAt: new Date('2023-12-30T00:00:00.000Z'),
+      updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+    },
+  ],
+};
+
+export const entriesBySubgroup = {
+  sg1: [
+    {
+      id: 'e1',
+      title: 'Protein research',
+      content: '<p>Findings…</p>',
+      status: 'none',
+      archived: false,
+      user_sort: 0,
+      subgroupId: 'sg1',
+      userId: notebook.userId,
+      createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2024-01-02T00:00:00.000Z'),
+      tags: [
+        { id: 't1', name: 'Biology', code: 'bio' },
+      ],
+    },
+    {
+      id: 'e2',
+      title: 'Synthesis backlog',
+      content: '<p>Draft</p>',
+      status: 'draft',
+      archived: false,
+      user_sort: 1,
+      subgroupId: 'sg1',
+      userId: notebook.userId,
+      createdAt: new Date('2024-01-02T00:00:00.000Z'),
+      updatedAt: new Date('2024-01-04T00:00:00.000Z'),
+      tags: [
+        { id: 't2', name: 'Writing', code: 'write' },
+      ],
+    },
+    {
+      id: 'e3',
+      title: 'Archived interview',
+      content: '<p>Hidden</p>',
+      status: 'none',
+      archived: true,
+      user_sort: 2,
+      subgroupId: 'sg1',
+      userId: notebook.userId,
+      createdAt: new Date('2024-01-03T00:00:00.000Z'),
+      updatedAt: new Date('2024-01-03T12:00:00.000Z'),
+      tags: [],
+    },
+  ],
+  sg2: [
+    {
+      id: 'e4',
+      title: 'Interview notes',
+      content: '<p>Summaries</p>',
+      status: 'review',
+      archived: false,
+      user_sort: 0,
+      subgroupId: 'sg2',
+      userId: notebook.userId,
+      createdAt: new Date('2024-01-02T00:00:00.000Z'),
+      updatedAt: new Date('2024-01-03T00:00:00.000Z'),
+      tags: [
+        { id: 't3', name: 'Qual', code: 'qual' },
+      ],
+    },
+  ],
+  sg3: [
+    {
+      id: 'e5',
+      title: 'Legacy findings',
+      content: '<p>Old data</p>',
+      status: 'done',
+      archived: true,
+      user_sort: 0,
+      subgroupId: 'sg3',
+      userId: notebook.userId,
+      createdAt: new Date('2023-12-30T00:00:00.000Z'),
+      updatedAt: new Date('2023-12-31T00:00:00.000Z'),
+      tags: [],
+    },
+  ],
+};
+
+export function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+export function getGroupById(id) {
+  return groups.find(group => group.id === id) ?? null;
+}
+
+export function getSubgroupById(id) {
+  return Object.values(subgroupsByGroup)
+    .flat()
+    .find(subgroup => subgroup.id === id) ?? null;
+}


### PR DESCRIPTION
## Summary
- document the current notebook tree data-loading sequence to highlight redundant client round-trips
- author a notebook tree API contract describing the combined response, nested pagination hooks, and projection rules
- refactor GET /api/notebooks/[id]/tree to use shared pagination utilities, return scoped pagination metadata, and shape nested includes per the contract
- add fixtures and performance-focused tests that compare the legacy multi-endpoint flow with the new unified endpoint

## Testing
- npm test -- --runTestsByPath __tests__/api/notebookTree.performance.test.js

------
https://chatgpt.com/codex/tasks/task_b_68d70eb04348832d93f4797108f40c58