### PR TITLE
Allow entries to be created without body content

### DIFF
--- a/pages/api/entries/index.js
+++ b/pages/api/entries/index.js
@@ -161,8 +161,8 @@ export default async function handler(req, res) {
     if (!title || typeof title !== 'string') {
       return res.status(400).json({ error: 'Title is required and must be a string' });
     }
-    if (!content || typeof content !== 'string') {
-      return res.status(400).json({ error: 'Content is required and must be a string' });
+    if (content !== undefined && typeof content !== 'string') {
+      return res.status(400).json({ error: 'Content must be a string' });
     }
     if (!subgroupId || typeof subgroupId !== 'string') {
       return res.status(400).json({ error: 'subgroupId is required and must be a string' });
@@ -177,6 +177,7 @@ export default async function handler(req, res) {
     }
 
     const entryStatus = status ?? DEFAULT_ENTRY_STATUS;
+    const entryContent = typeof content === 'string' ? content : '';
 
     try {
       // Verify subgroup ownership
@@ -195,7 +196,7 @@ export default async function handler(req, res) {
       const newEntry = await prisma.entry.create({
         data: {
           title,
-          content,
+          content: entryContent,
           userId,
           status: entryStatus,
           subgroupId,

--- a/pages/api/entries/status.test.js
+++ b/pages/api/entries/status.test.js
@@ -123,6 +123,40 @@ describe('POST /api/entries', () => {
     expect(res._getJSON()).toEqual(createdEntry);
   });
 
+  it('allows creating an entry without content', async () => {
+    const subgroupId = 'sub-1';
+    mockSubgroupDelegate.findUnique.mockResolvedValue({
+      id: subgroupId,
+      group: { notebook: { userId: 'user-123' } },
+    });
+    mockEntryDelegate.count.mockResolvedValue(0);
+    const createdEntry = {
+      id: 'entry-3',
+      status: DEFAULT_ENTRY_STATUS,
+      content: '',
+    };
+    mockEntryDelegate.create.mockResolvedValue(createdEntry);
+
+    const req = createRequest({
+      method: 'POST',
+      body: {
+        title: 'New entry',
+        subgroupId,
+      },
+    });
+    const res = createResponse();
+
+    await handlerIndex(req, res);
+
+    expect(res.statusCode).toBe(201);
+    expect(mockEntryDelegate.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ content: '' }),
+      })
+    );
+    expect(res._getJSON()).toEqual(createdEntry);
+  });
+
   it('rejects an invalid status value', async () => {
     const req = createRequest({
       method: 'POST',

--- a/src/components/Desk/DeskSurface.jsx
+++ b/src/components/Desk/DeskSurface.jsx
@@ -733,8 +733,7 @@ export default function DeskSurface({
     const MAX_RETRIES = 3;
     const interval = setInterval(() => {
       const hasTitle = title.trim().length > 0;
-      const hasContent = content.trim().length > 0;
-      if (hasTitle && hasContent) {
+      if (hasTitle) {
         handleNotebookSave();
         retries = 0;
       } else if (retries >= MAX_RETRIES - 1) {


### PR DESCRIPTION
## Summary
- allow entry creation API to accept missing content and default to an empty string
- trigger editor autosave whenever a titled entry is open, regardless of body text
- cover the new behavior with a POST /api/entries unit test

## Testing
- npm test -- --runTestsByPath pages/api/entries/status.test.js

------
https://chatgpt.com/codex/tasks/task_b_68daa8379150832d950c93a1814e2d52