### PR TITLE
Add Messaging surface, editable persona presets, and AI auto-naming

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,9 @@ former standalone `bitter-queen` project) so playground data can cross-reference
 journal entries and tags. It is NOT a separate DB anymore.
 
 - **Models:** `Todo` (+ `Priority` enum) live in `prisma/schema.prisma` alongside `JournalEntry`. A `Todo` may optionally link to a `JournalEntry` via `entryId` (relation `Todo.entry` / `JournalEntry.todos`, `onDelete: SetNull`). The to-dos UI links/unlinks entries via a picker fed by `GET /chris/api/entries`.
+- **Modules:** To-dos, Projects, Journal (shared with IMW), Shopping, Prompts, and **Messaging** (`/chris/messages`). Module cards are listed in `app/chris/page.tsx`.
 - **Client:** uses the standard `import { prisma } from "@/lib/prisma"`.
+- **Migrations workflow (`migrate dev` — the canonical path):** migration history is back in sync with the live DB as of `20260602184246_add_prompt_status_and_messaging` (that migration baselined earlier `db push` drift — `Prompt.status` + the `Message` table). **Use `prisma migrate dev` for all schema changes; do NOT use `db push`** (it silently re-introduces drift that later forces a destructive reset). See the "Prisma Migrations" section below for the required shadow-DB step on Neon and the dev-server restart gotcha.
 - **Owner gate:** `lib/playground-auth.ts` (`getPlaygroundUserId()` returns a userId only for `PLAYGROUND_OWNER_EMAIL`) + `app/chris/OwnerGate.tsx` (client redirect). Non-owners are blocked at both the UI and the API.
 - **Layout:** `app/chris/layout.tsx` is self-contained — no IMW sidebar/theme. `SidebarWrapper` hides the IMW sidebar on `/chris*`.
 
@@ -84,8 +86,29 @@ The next milestone is **Phase 4 — Quiet Beta** (3–5 trusted ND users).
 | Node | 24.x |
 
 ### Key Prisma Notes
-- Prisma 7 no longer accepts `DATABASE_URL` inside `schema.prisma`. Connection string lives in `prisma.config.ts`.
+- Prisma 7 no longer accepts `DATABASE_URL` inside `schema.prisma`. Connection string lives in `prisma.config.ts` (loads `.env` via `dotenv/config`; the value is in both `.env` and `.env.local`).
 - Always run `prisma generate` before `next build`. Build script: `"build": "prisma generate && next build"`.
+
+#### Migrations workflow (read before any schema change)
+**Always use `prisma migrate dev` — never `prisma db push`.** `db push` mutates the live DB without writing a migration file, creating drift that a later `migrate dev` can only resolve by offering a **destructive reset**. History was re-baselined on 2026-06-02 to undo exactly that; don't reintroduce it.
+
+Neon can't host the shadow database `migrate dev` needs (the pooled connection can't `CREATE DATABASE`), so spin up a throwaway local Postgres and point `SHADOW_DATABASE_URL` at it. `prisma.config.ts` already wires `datasource.shadowDatabaseUrl = process.env.SHADOW_DATABASE_URL` (unset = ignored at runtime).
+
+```bash
+# one-time-ish: throwaway shadow Postgres (Homebrew postgresql@14)
+initdb -D /tmp/imw-shadow-pg -U postgres --no-locale --encoding=UTF8
+pg_ctl -D /tmp/imw-shadow-pg -o "-p 5433" -l /tmp/shadow-pg.log start
+createdb -p 5433 -U postgres shadow
+
+# then, for any schema change:
+SHADOW_DATABASE_URL="postgresql://postgres@127.0.0.1:5433/shadow" \
+  npx prisma migrate dev --name <change_name>
+
+pg_ctl -D /tmp/imw-shadow-pg stop   # tear down when done
+```
+
+- **Restart the dev server after adding a model/field.** The running Next process caches the generated Prisma client; new models otherwise 500 with `Cannot read properties of undefined (reading 'create')` until you `pkill -f "next dev"` + restart (or re-launch the preview).
+- **Baselining drift without data loss** (if it ever happens again): generate the catch-up SQL with `prisma migrate diff --from-migrations prisma/migrations --to-schema prisma/schema.prisma --script` (needs `SHADOW_DATABASE_URL`), drop it into a new `prisma/migrations/<ts>_<name>/migration.sql`, then `prisma migrate resolve --applied <ts>_<name>` so it records as applied **without** re-running against prod. Verify with `migrate diff --from-migrations … --to-config-datasource --exit-code` → "No difference detected".
 
 ### Key AI SDK Notes
 - Use `maxOutputTokens` (not `maxTokens`) in Vercel AI SDK v6.
@@ -274,11 +297,43 @@ components/
 
 ## AI Features
 
-### Title Generation (`/api/entries/[id]/generate-title`)
-- Triggers automatically at ~30 words (debounced 1500ms); **pending ticket to increase threshold by ~25–35 chars** (see Backlog)
+### Shared title-generation helper (`lib/generate-title.ts`)
+All three auto-naming surfaces use this one module. It exports:
+- `generateTitle(content, kind)` — calls Claude, returns a string or null. `kind` is `"journal"` (evocative, friend-like voice) or `"prompt"` (descriptive, file-name-style voice).
+- `countWords(text)` + `MIN_TITLE_WORDS = 10` — callers use these to gate thin drafts before calling `generateTitle`.
+- Always strips stray quotes/fences from Claude's reply.
+- Throws on Anthropic failure; callers catch and treat naming as best-effort.
+
+### Title Generation — main journal (`/api/entries/[id]/generate-title`)
+- Triggers on save when plain text ≥ 10 chars (called from `app/journal/page.tsx`)
 - `id` accepts `"new"` for the composer (no ownership check needed)
 - Composer title input has no placeholder — stays blank until AI populates it
 - User can override at any time; manual titles are never overwritten by AI
+- Gated by `asd_user` plan check (unlike the playground routes below)
+
+### Title Generation — playground prompts (`/chris/api/prompts/[id]/generate-title`)
+- Owner-gated (no plan check — `/chris` is already owner-only)
+- Fires after prompt save and after a content edit while still untitled
+- Uses `"prompt"` voice: descriptive label for what the prompt *does*
+- Displayed in `PromptRow` as bold title above the dimmed content preview
+- Never overwrites a title the user typed manually
+
+### Title Generation — playground journal (`/chris/api/entries/[id]/generate-title`)
+- Owner-gated; mirrors the prompt route but uses `"journal"` voice
+- Fires after entry save (if no manual title supplied) and after an untitled content edit
+- Persists via standard `/api/entries/[id]` PATCH
+
+### Messaging — message translation with editable persona presets (`/chris/messages`)
+Owner-only playground tool for drafting Slack/email/text messages and rewriting them for how they'll *land*. Three-stage flow: **draft → response → finalDraft**, tracked by `Message.status` (`"draft" | "response" | "final"`).
+- **Two orthogonal dimensions:** `channel` (`slack|email|text` — delivery medium, appended as a short note) and **`mode`** (`professional|dating|friends` — the persona/voice).
+- `Message` model: `channel`, `draft` (TipTap JSON), `response` (plain text), `finalDraft` (TipTap JSON), `status`.
+- `MessagePreset` model: one row per `(userId, key)` where `key` is a `MessageMode`. `prompt` is the **owner-editable** system prompt; seeded from `DEFAULT_MODE_PROMPTS` on first `GET /chris/api/message-presets`. Edited via the "✎ edit prompts" modal on the messages page.
+- `lib/translate-message.ts` (server-only — never import into a client component) — `translateMessage(plainText, channel, systemPrompt)`. Caller supplies the preset's prompt; the channel medium-note is appended. Exports `MESSAGE_MODES`, `DEFAULT_MODE_PROMPTS`, `isMessageMode`, channel helpers. **Mode metadata is duplicated in `page.tsx` (`MODES`)** on purpose, so the client never imports this server module.
+- Defaults: *professional* = neurodivergent→neurotypical top-down-processing rewrite for an educated workplace (lead with the headline, make implicit social signals explicit, soften bluntness, no small talk/emoji, preserve meaning); *dating* = warm/genuine/confident messages to women on dating apps; *friends* = casual warm messages. All editable + "reset to default".
+- Routes (owner-gated via `getPlaygroundUserId`, no `asd_user` plan gate): `GET/POST /chris/api/messages`, `PATCH/DELETE /chris/api/messages/[id]`, `POST /chris/api/messages/[id]/translate` (body `{ channel?, mode? }` — loads that mode's preset prompt), `POST /chris/api/messages/reorder`, `GET /chris/api/message-presets` (get-or-seed), `PATCH /chris/api/message-presets/[id]` (`{ prompt? }` or `{ reset: true }`).
+- `status` auto-advances server-side: `translate` sets `response`; saving a non-empty `finalDraft` sets `final`.
+- UI: composer header has the **mode dropdown** (persisted in `localStorage` `chris.messages.mode`) + channel toggle + "edit prompts" button. Feed of collapsible cards; expanded **MessageWorkspace** is the numbered 3-step stepper showing the active mode; "Use as final draft" seeds step 3 (editor remounts via `key`). The **PromptModal** has a tab per mode + textarea + save/reset.
+- Replaced the old "Automations" stub card on the `/chris` landing.
 
 ### Category Classification (`/api/entries/[id]/analyze`)
 - Sends entry content to Claude with the IMW lived experience taxonomy

--- a/app/api/entries/[id]/generate-title/route.ts
+++ b/app/api/entries/[id]/generate-title/route.ts
@@ -1,28 +1,13 @@
 import { auth } from "@clerk/nextjs/server";
 import { NextRequest, NextResponse } from "next/server";
-import { generateText } from "ai";
 import { prisma } from "@/lib/prisma";
-import { anthropic, CLAUDE_MODEL } from "@/lib/ai";
+import { generateTitle } from "@/lib/generate-title";
 
 async function getUserId(): Promise<string | null> {
   if (process.env.NEXT_PUBLIC_DEV_BYPASS_AUTH === "true") return "dev-user-local";
   const { userId } = await auth();
   return userId;
 }
-
-const TITLE_SYSTEM_PROMPT = `You are helping someone give a name to something they experienced and wrote about.
-
-They've written a journal entry about their life — often about hard moments, sensory experiences, emotional days, or things that were difficult to navigate. Your job is to read what they wrote and suggest a short, evocative title that feels true to their experience.
-
-The title should:
-- Be 8 words or fewer
-- Reflect what actually happened or what they felt — not a diagnostic label
-- Sound like something a thoughtful, caring friend might say, not a clinician
-- Capture the emotional truth or the specific moment
-- Use plain, human language — no jargon, no clinical framing
-- Feel personal and specific, not generic
-
-Return ONLY the title itself — no quotes, no punctuation at the end, nothing else.`;
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -60,14 +45,8 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   }
 
   try {
-    const { text } = await generateText({
-      model: anthropic(CLAUDE_MODEL),
-      system: TITLE_SYSTEM_PROMPT,
-      prompt: content.trim(),
-      maxOutputTokens: 60,
-    });
-
-    return NextResponse.json({ title: text.trim() });
+    const title = await generateTitle(content, "journal");
+    return NextResponse.json({ title });
   } catch (err) {
     console.error("Title generation failed:", err);
     return NextResponse.json({ error: "Title generation unavailable" }, { status: 503 });

--- a/app/chris/api/entries/[id]/generate-title/route.ts
+++ b/app/chris/api/entries/[id]/generate-title/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getPlaygroundUserId } from "@/lib/playground-auth";
+import { extractPlainText, parseEntryContent } from "@/lib/tiptap-content";
+import { countWords, generateTitle, MIN_TITLE_WORDS } from "@/lib/generate-title";
+
+// POST /chris/api/entries/[id]/generate-title
+// Owner-gated auto-naming for the playground journal. Mirrors the main app's
+// /api/entries/[id]/generate-title but without the asd_user plan gate, since the
+// playground is already owner-only. Reads the entry's stored content and returns
+// an AI-suggested title. Returns { title: null } (200) when too short or Claude
+// is unavailable — naming is best-effort and never blocks a save.
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const userId = await getPlaygroundUserId();
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { id } = await params;
+  const entry = await prisma.journalEntry.findFirst({ where: { id, userId } });
+  if (!entry) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  let plainText = "";
+  try {
+    plainText = extractPlainText(parseEntryContent(entry.content));
+  } catch {
+    plainText = entry.content;
+  }
+
+  if (countWords(plainText) < MIN_TITLE_WORDS) {
+    return NextResponse.json({ title: null });
+  }
+
+  try {
+    const title = await generateTitle(plainText, "journal");
+    return NextResponse.json({ title });
+  } catch (err) {
+    console.error("Playground journal title generation failed:", err);
+    return NextResponse.json({ title: null });
+  }
+}

--- a/app/chris/api/message-presets/[id]/route.ts
+++ b/app/chris/api/message-presets/[id]/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getPlaygroundUserId } from "@/lib/playground-auth";
+import { DEFAULT_MODE_PROMPTS, isMessageMode } from "@/lib/translate-message";
+
+// PATCH /chris/api/message-presets/[id]
+// Edit a preset's prompt (and optionally its label). Body: { prompt?, label?,
+// reset? }. When `reset` is true, restore the mode's built-in default prompt.
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const userId = await getPlaygroundUserId();
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { id } = await params;
+  const existing = await prisma.messagePreset.findFirst({ where: { id, userId } });
+  if (!existing) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const body = await req.json().catch(() => ({}));
+  const data: Record<string, unknown> = {};
+
+  if (body.reset === true && isMessageMode(existing.key)) {
+    data.prompt = DEFAULT_MODE_PROMPTS[existing.key];
+  } else if (typeof body.prompt === "string") {
+    if (body.prompt.trim() === "") {
+      return NextResponse.json({ error: "Prompt cannot be empty" }, { status: 400 });
+    }
+    data.prompt = body.prompt;
+  }
+
+  if (typeof body.label === "string" && body.label.trim()) {
+    data.label = body.label.trim();
+  }
+
+  if (Object.keys(data).length === 0) {
+    return NextResponse.json({ error: "Nothing to update" }, { status: 400 });
+  }
+
+  const preset = await prisma.messagePreset.update({ where: { id }, data });
+  return NextResponse.json({ preset });
+}

--- a/app/chris/api/message-presets/route.ts
+++ b/app/chris/api/message-presets/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getPlaygroundUserId } from "@/lib/playground-auth";
+import { MESSAGE_MODES, DEFAULT_MODE_PROMPTS } from "@/lib/translate-message";
+
+// GET /chris/api/message-presets
+// Returns the owner's three editable persona presets, seeding any that don't
+// exist yet from the defaults in lib/translate-message.ts. Idempotent.
+export async function GET() {
+  const userId = await getPlaygroundUserId();
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const existing = await prisma.messagePreset.findMany({ where: { userId } });
+  const byKey = new Map(existing.map((p) => [p.key, p]));
+
+  // Seed missing presets (first load, or after a new mode is added).
+  const toCreate = MESSAGE_MODES.filter((m) => !byKey.has(m.value)).map((m, i) => ({
+    userId,
+    key: m.value,
+    label: m.label,
+    prompt: DEFAULT_MODE_PROMPTS[m.value],
+    sortOrder: MESSAGE_MODES.findIndex((x) => x.value === m.value) + i * 0,
+  }));
+  if (toCreate.length) {
+    await prisma.messagePreset.createMany({ data: toCreate, skipDuplicates: true });
+  }
+
+  const presets = await prisma.messagePreset.findMany({
+    where: { userId },
+    orderBy: { sortOrder: "asc" },
+  });
+  // Stable order matching MESSAGE_MODES regardless of stored sortOrder.
+  presets.sort(
+    (a, b) =>
+      MESSAGE_MODES.findIndex((m) => m.value === a.key) -
+      MESSAGE_MODES.findIndex((m) => m.value === b.key)
+  );
+  return NextResponse.json({ presets });
+}

--- a/app/chris/api/messages/[id]/route.ts
+++ b/app/chris/api/messages/[id]/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getPlaygroundUserId } from "@/lib/playground-auth";
+import { isMessageChannel } from "@/lib/translate-message";
+
+const VALID_STATUSES = ["draft", "response", "final"];
+
+// PATCH /chris/api/messages/[id]
+// Updatable: draft, finalDraft, channel, status. (response is set by /translate.)
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const userId = await getPlaygroundUserId();
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { id } = await params;
+  const existing = await prisma.message.findFirst({ where: { id, userId } });
+  if (!existing) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const body = await req.json().catch(() => ({}));
+  const data: Record<string, unknown> = {};
+
+  if (typeof body.draft === "string") data.draft = body.draft;
+  if (isMessageChannel(body.channel)) data.channel = body.channel;
+
+  if ("finalDraft" in body) {
+    const v = body.finalDraft;
+    const cleaned = typeof v === "string" && v.trim() ? v : null;
+    data.finalDraft = cleaned;
+    // Auto-advance the stage when a final draft lands; fall back to whichever
+    // earlier stage is still true when it's cleared.
+    if (cleaned) data.status = "final";
+    else data.status = existing.response ? "response" : "draft";
+  }
+
+  if (typeof body.status === "string" && VALID_STATUSES.includes(body.status)) {
+    data.status = body.status;
+  }
+
+  const message = await prisma.message.update({ where: { id }, data });
+  return NextResponse.json({ message });
+}
+
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const userId = await getPlaygroundUserId();
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { id } = await params;
+  const existing = await prisma.message.findFirst({ where: { id, userId } });
+  if (!existing) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  await prisma.message.delete({ where: { id } });
+  return NextResponse.json({ ok: true });
+}

--- a/app/chris/api/messages/[id]/translate/route.ts
+++ b/app/chris/api/messages/[id]/translate/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getPlaygroundUserId } from "@/lib/playground-auth";
+import { extractPlainText, parseEntryContent } from "@/lib/tiptap-content";
+import {
+  DEFAULT_MODE_PROMPTS,
+  isMessageChannel,
+  isMessageMode,
+  translateMessage,
+  type MessageMode,
+} from "@/lib/translate-message";
+
+// POST /chris/api/messages/[id]/translate
+// Reads the stored draft and asks Claude to rewrite it for the message's channel
+// using the chosen persona preset (mode). Stores the result as `response` and
+// advances status. Body: { channel?, mode? } — mode picks which editable preset
+// prompt to send.
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const userId = await getPlaygroundUserId();
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { id } = await params;
+  const existing = await prisma.message.findFirst({ where: { id, userId } });
+  if (!existing) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const body = await req.json().catch(() => ({}));
+  const channel = isMessageChannel(body.channel) ? body.channel : (existing.channel as "slack" | "email" | "text");
+  const mode: MessageMode = isMessageMode(body.mode) ? body.mode : "professional";
+
+  // Resolve the system prompt from the owner's editable preset for this mode,
+  // falling back to the built-in default if it hasn't been seeded yet.
+  const preset = await prisma.messagePreset.findFirst({ where: { userId, key: mode } });
+  const systemPrompt = preset?.prompt?.trim() || DEFAULT_MODE_PROMPTS[mode];
+
+  let plainText = "";
+  try {
+    plainText = extractPlainText(parseEntryContent(existing.draft));
+  } catch {
+    plainText = existing.draft;
+  }
+  if (plainText.trim().length < 2) {
+    return NextResponse.json({ error: "Draft is empty" }, { status: 400 });
+  }
+
+  try {
+    const response = await translateMessage(plainText, channel, systemPrompt);
+    const message = await prisma.message.update({
+      where: { id },
+      data: {
+        response,
+        channel,
+        // Don't downgrade a message that already has a final draft.
+        status: existing.status === "final" ? "final" : "response",
+      },
+    });
+    return NextResponse.json({ message });
+  } catch (err) {
+    console.error("Message translation failed:", err);
+    return NextResponse.json({ error: "Translation unavailable" }, { status: 503 });
+  }
+}

--- a/app/chris/api/messages/reorder/route.ts
+++ b/app/chris/api/messages/reorder/route.ts
@@ -1,0 +1,12 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getPlaygroundUserId } from "@/lib/playground-auth";
+import { reorderForUser } from "@/lib/reorder";
+
+export async function POST(req: NextRequest) {
+  const userId = await getPlaygroundUserId();
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const body = await req.json().catch(() => ({}));
+  const ids = Array.isArray(body.ids) ? (body.ids as string[]) : [];
+  await reorderForUser("message", ids, userId);
+  return NextResponse.json({ ok: true });
+}

--- a/app/chris/api/messages/route.ts
+++ b/app/chris/api/messages/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getPlaygroundUserId } from "@/lib/playground-auth";
+import { isMessageChannel } from "@/lib/translate-message";
+
+// GET /chris/api/messages — owner's message drafts, ordered for the feed.
+export async function GET() {
+  const userId = await getPlaygroundUserId();
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const messages = await prisma.message.findMany({
+    where: { userId },
+    orderBy: [{ sortOrder: "asc" }, { updatedAt: "desc" }],
+  });
+  return NextResponse.json({ messages });
+}
+
+// POST /chris/api/messages — create a draft. Body: { draft, channel? }
+export async function POST(req: NextRequest) {
+  const userId = await getPlaygroundUserId();
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const body = await req.json().catch(() => ({}));
+  const draft = typeof body.draft === "string" ? body.draft : "";
+  if (!draft || draft.trim() === "") {
+    return NextResponse.json({ error: "Draft is required" }, { status: 400 });
+  }
+  const channel = isMessageChannel(body.channel) ? body.channel : "email";
+
+  const message = await prisma.message.create({
+    data: { userId, draft, channel, status: "draft" },
+  });
+  return NextResponse.json({ message }, { status: 201 });
+}

--- a/app/chris/api/prompts/[id]/generate-title/route.ts
+++ b/app/chris/api/prompts/[id]/generate-title/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getPlaygroundUserId } from "@/lib/playground-auth";
+import { extractPlainText, parseEntryContent } from "@/lib/tiptap-content";
+import { countWords, generateTitle, MIN_TITLE_WORDS } from "@/lib/generate-title";
+
+// POST /chris/api/prompts/[id]/generate-title
+// Owner-gated. Reads the prompt's stored content and returns an AI-suggested
+// title. Returns { title: null } (200) when the prompt is too short to name or
+// Claude is unavailable — naming is best-effort and never blocks the UI.
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const userId = await getPlaygroundUserId();
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { id } = await params;
+  const prompt = await prisma.prompt.findFirst({ where: { id, userId } });
+  if (!prompt) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  let plainText = "";
+  try {
+    plainText = extractPlainText(parseEntryContent(prompt.content));
+  } catch {
+    plainText = prompt.content;
+  }
+
+  if (countWords(plainText) < MIN_TITLE_WORDS) {
+    return NextResponse.json({ title: null });
+  }
+
+  try {
+    const title = await generateTitle(plainText, "prompt");
+    return NextResponse.json({ title });
+  } catch (err) {
+    console.error("Prompt title generation failed:", err);
+    return NextResponse.json({ title: null });
+  }
+}

--- a/app/chris/journal/page.tsx
+++ b/app/chris/journal/page.tsx
@@ -209,6 +209,36 @@ export default function JournalPage() {
       setContent("");
       setMood(null);
       setEditorKey((k) => k + 1);
+      // Auto-name in the background when the writer didn't supply a title.
+      if (!entry.title) void autoNameEntry(entry.id);
+    }
+  };
+
+  // Ask Claude to name the entry from its saved content, then persist it — but
+  // only if the entry is still untitled (the writer may have added one). The
+  // generate-title route is owner-gated under /chris; the PATCH reuses the main
+  // entries route, same as manual edits.
+  const autoNameEntry = async (id: string) => {
+    try {
+      const res = await fetch(`/chris/api/entries/${id}/generate-title`, {
+        method: "POST",
+      });
+      if (!res.ok) return;
+      const { title: aiTitle } = await res.json();
+      if (!aiTitle) return;
+
+      const patchRes = await fetch(`/api/entries/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: aiTitle }),
+      });
+      if (!patchRes.ok) return;
+      const updated = await patchRes.json();
+      setEntries((prev) =>
+        prev.map((e) => (e.id === id && !e.title ? updated : e))
+      );
+    } catch {
+      // best-effort — leave the entry untitled on failure
     }
   };
 
@@ -425,8 +455,13 @@ export default function JournalPage() {
               onEdit={expandEdit}
               onCancelEdit={collapseEdit}
               onSaveEdit={async (id, data) => {
+                const existing = entries.find((e) => e.id === id);
                 await patchEntry(id, data);
                 collapseEdit();
+                // Re-name on content edits while still untitled.
+                if (existing && !data.title?.trim() && !existing.title) {
+                  void autoNameEntry(id);
+                }
               }}
               applyReorder={(next) => {
                 setEntries(next);

--- a/app/chris/messages/page.tsx
+++ b/app/chris/messages/page.tsx
@@ -1,0 +1,1470 @@
+"use client";
+
+import { useEffect, useMemo, useState, useCallback } from "react";
+import Link from "next/link";
+import { IMWEditor } from "@/components/editor";
+import { parseEntryContent, extractPlainText } from "@/lib/tiptap-content";
+import { useDragReorder } from "@/app/chris/_lib/dragReorder";
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+type Channel = "slack" | "email" | "text";
+type Status = "draft" | "response" | "final";
+type Mode = "professional" | "dating" | "friends";
+
+type Message = {
+  id: string;
+  channel: Channel;
+  draft: string; // TipTap JSON
+  response: string | null; // plain text
+  finalDraft: string | null; // TipTap JSON
+  status: Status;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type Preset = {
+  id: string;
+  key: Mode;
+  label: string;
+  prompt: string;
+};
+
+const CHANNELS: { value: Channel; label: string }[] = [
+  { value: "slack", label: "Slack" },
+  { value: "email", label: "Email" },
+  { value: "text", label: "Text" },
+];
+
+// Mode metadata is duplicated client-side on purpose: lib/translate-message.ts
+// pulls in server-only code (the Anthropic client), so it must not be imported
+// here. Prompt text lives in the DB and is loaded via /chris/api/message-presets.
+const MODES: { value: Mode; label: string; blurb: string }[] = [
+  { value: "professional", label: "Professional", blurb: "Neurodivergent → neurotypical, professional workplace" },
+  { value: "dating", label: "Dating", blurb: "Messages to women on dating apps" },
+  { value: "friends", label: "Friends", blurb: "Casual messages to friends" },
+];
+
+const ALL_CHANNELS = "__all_channels__";
+const ALL_STATUSES = "__all_statuses__";
+
+const STATUSES: { value: Status; label: string; color: string }[] = [
+  { value: "draft", label: "Draft", color: "#9aa0aa" },
+  { value: "response", label: "Suggested", color: "#60a5fa" },
+  { value: "final", label: "Final", color: "#34d399" },
+];
+
+// ── Palette (shared with the rest of the playground) ─────────────────────────
+
+const C = {
+  bg: "#0e0f12",
+  card: "#15171c",
+  cardHover: "#181b21",
+  border: "#23262d",
+  borderSoft: "#1f2228",
+  text: "#e7e9ee",
+  textDim: "#9aa0aa",
+  textFaint: "#6b7280",
+  accent: "#c9a86a",
+  accentText: "#1a1710",
+  danger: "#e0736a",
+  suggest: "#60a5fa",
+};
+const MONO = 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace';
+const LAST_CHANNEL_KEY = "chris.messages.lastChannel";
+const LAST_STATUS_KEY = "chris.messages.lastStatusFilter";
+const LAST_MODE_KEY = "chris.messages.mode";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function previewJSON(content: string, max = 220): string {
+  try {
+    return extractPlainText(parseEntryContent(content)).slice(0, max);
+  } catch {
+    return content.slice(0, max);
+  }
+}
+
+function isJSONEmpty(content: string): boolean {
+  return previewJSON(content, 500).trim().length === 0;
+}
+
+function statusInfo(s: Status) {
+  return STATUSES.find((x) => x.value === s) ?? STATUSES[0];
+}
+
+function formatRelative(iso: string): string {
+  const d = new Date(iso);
+  const mins = Math.floor((Date.now() - d.getTime()) / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  if (days < 7) return `${days}d ago`;
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+// ── Channel segmented control ────────────────────────────────────────────────
+
+function ChannelToggle({
+  value,
+  onChange,
+  size = "md",
+}: {
+  value: Channel;
+  onChange: (c: Channel) => void;
+  size?: "sm" | "md";
+}) {
+  const pad = size === "sm" ? "4px 10px" : "6px 14px";
+  const fs = size === "sm" ? 12 : 13;
+  return (
+    <div
+      style={{
+        display: "inline-flex",
+        border: `1px solid ${C.border}`,
+        borderRadius: 999,
+        padding: 2,
+        gap: 2,
+        background: C.bg,
+      }}
+    >
+      {CHANNELS.map((ch) => {
+        const active = ch.value === value;
+        return (
+          <button
+            key={ch.value}
+            onClick={() => onChange(ch.value)}
+            style={{
+              border: "none",
+              borderRadius: 999,
+              padding: pad,
+              fontSize: fs,
+              fontFamily: MONO,
+              cursor: "pointer",
+              background: active ? C.accent : "transparent",
+              color: active ? C.accentText : C.textDim,
+              fontWeight: active ? 600 : 400,
+              transition: "background 0.12s ease, color 0.12s ease",
+            }}
+          >
+            {ch.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+// ── Page ─────────────────────────────────────────────────────────────────────
+
+export default function MessagesPage() {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  // Composer
+  const [draftContent, setDraftContent] = useState("");
+  const [channel, setChannel] = useState<Channel>("email");
+  const [editorKey, setEditorKey] = useState(0);
+  const [busy, setBusy] = useState(false);
+
+  // Persona presets + active mode
+  const [presets, setPresets] = useState<Preset[]>([]);
+  const [mode, setModeState] = useState<Mode>("professional");
+  const setMode = useCallback((m: Mode) => {
+    setModeState(m);
+    if (typeof window !== "undefined") localStorage.setItem(LAST_MODE_KEY, m);
+  }, []);
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const [editingId, setEditingId] = useState<string | null>(null);
+
+  const transitionTo = (apply: () => void) => {
+    const doc = document as unknown as { startViewTransition?: (cb: () => void) => unknown };
+    if (typeof document !== "undefined" && doc.startViewTransition) doc.startViewTransition(apply);
+    else apply();
+  };
+  const expandEdit = (id: string) => transitionTo(() => setEditingId(id));
+  const collapseEdit = () => transitionTo(() => setEditingId(null));
+
+  const [channelFilter, setChannelFilterState] = useState(ALL_CHANNELS);
+  const setChannelFilter = useCallback((v: string) => {
+    setChannelFilterState(v);
+    if (typeof window !== "undefined") localStorage.setItem(LAST_CHANNEL_KEY, v);
+  }, []);
+  const [statusFilter, setStatusFilterState] = useState(ALL_STATUSES);
+  const setStatusFilter = useCallback((v: string) => {
+    setStatusFilterState(v);
+    if (typeof window !== "undefined") localStorage.setItem(LAST_STATUS_KEY, v);
+  }, []);
+
+  // Load
+  useEffect(() => {
+    (async () => {
+      try {
+        const [msgRes, presetRes] = await Promise.all([
+          fetch("/chris/api/messages"),
+          fetch("/chris/api/message-presets"),
+        ]);
+        const data = await msgRes.json();
+        setMessages(data.messages ?? []);
+        const pdata = await presetRes.json();
+        setPresets(pdata.presets ?? []);
+
+        const savedChannel = localStorage.getItem(LAST_CHANNEL_KEY);
+        if (savedChannel === ALL_CHANNELS || CHANNELS.some((c) => c.value === savedChannel)) {
+          setChannelFilterState(savedChannel!);
+        }
+        const savedStatus = localStorage.getItem(LAST_STATUS_KEY);
+        if (savedStatus === ALL_STATUSES || STATUSES.some((s) => s.value === savedStatus)) {
+          setStatusFilterState(savedStatus!);
+        }
+        const savedMode = localStorage.getItem(LAST_MODE_KEY);
+        if (savedMode && MODES.some((m) => m.value === savedMode)) {
+          setModeState(savedMode as Mode);
+        }
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  const savePreset = async (id: string, body: { prompt?: string; reset?: boolean }) => {
+    const res = await fetch(`/chris/api/message-presets/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) return null;
+    const { preset } = await res.json();
+    setPresets((prev) => prev.map((p) => (p.id === id ? preset : p)));
+    return preset as Preset;
+  };
+
+  // ── Actions ────────────────────────────────────────────────────────────────
+
+  const upsertLocal = (msg: Message) =>
+    setMessages((prev) => {
+      const exists = prev.some((m) => m.id === msg.id);
+      return exists ? prev.map((m) => (m.id === msg.id ? msg : m)) : [msg, ...prev];
+    });
+
+  // Create a draft from the composer. Returns the new message (or null).
+  const createDraft = async (): Promise<Message | null> => {
+    if (isJSONEmpty(draftContent)) return null;
+    const res = await fetch("/chris/api/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ draft: draftContent, channel }),
+    });
+    if (!res.ok) return null;
+    const { message } = await res.json();
+    upsertLocal(message);
+    return message;
+  };
+
+  const resetComposer = () => {
+    setDraftContent("");
+    setEditorKey((k) => k + 1);
+  };
+
+  // Save draft only (no translation).
+  const handleSaveDraft = async () => {
+    setBusy(true);
+    try {
+      const msg = await createDraft();
+      if (msg) resetComposer();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // Save the draft AND translate it, then open the workspace on the result.
+  const handleGetSuggestion = async () => {
+    setBusy(true);
+    try {
+      const msg = await createDraft();
+      if (!msg) return;
+      resetComposer();
+      const translated = await translate(msg.id, channel);
+      expandEdit(translated?.id ?? msg.id);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // Ask Claude to translate the stored draft (optionally for a new channel).
+  // Persists draft edits passed in first so the rewrite reflects them.
+  const translate = async (
+    id: string,
+    forChannel: Channel,
+    draftOverride?: string
+  ): Promise<Message | null> => {
+    if (draftOverride !== undefined) {
+      await fetch(`/chris/api/messages/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ draft: draftOverride, channel: forChannel }),
+      });
+    }
+    const res = await fetch(`/chris/api/messages/${id}/translate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ channel: forChannel, mode }),
+    });
+    if (!res.ok) return null;
+    const { message } = await res.json();
+    upsertLocal(message);
+    return message;
+  };
+
+  const patchMessage = async (
+    id: string,
+    body: { draft?: string; finalDraft?: string | null; channel?: Channel; status?: Status }
+  ): Promise<Message | null> => {
+    const res = await fetch(`/chris/api/messages/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) return null;
+    const { message } = await res.json();
+    upsertLocal(message);
+    return message;
+  };
+
+  const deleteMessage = async (id: string) => {
+    setMessages((prev) => prev.filter((m) => m.id !== id));
+    await fetch(`/chris/api/messages/${id}`, { method: "DELETE" });
+  };
+
+  // ── Derived ──────────────────────────────────────────────────────────────
+
+  const filtered = useMemo(() => {
+    let list = messages;
+    if (channelFilter !== ALL_CHANNELS) list = list.filter((m) => m.channel === channelFilter);
+    if (statusFilter !== ALL_STATUSES) list = list.filter((m) => m.status === statusFilter);
+    return list;
+  }, [messages, channelFilter, statusFilter]);
+
+  const draftEmpty = isJSONEmpty(draftContent);
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
+  return (
+    <main style={{ maxWidth: 720, margin: "0 auto", padding: "0 24px 96px" }}>
+      <header
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          height: 64,
+          borderBottom: `1px solid ${C.border}`,
+        }}
+      >
+        <Link href="/chris" style={{ textDecoration: "none", fontFamily: MONO, fontSize: 14 }}>
+          <span style={{ color: C.textFaint }}>~/chris/</span>
+          <span style={{ color: C.text }}>messages</span>
+        </Link>
+        <span style={{ fontFamily: MONO, fontSize: 12, color: C.textFaint }}>
+          {messages.length} message{messages.length === 1 ? "" : "s"}
+        </span>
+      </header>
+
+      {/* Composer — hidden while a workspace is open */}
+      {editingId === null && (
+        <section style={{ marginTop: 28 }}>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              flexWrap: "wrap",
+              gap: 10,
+              marginBottom: 12,
+            }}
+          >
+            <ModeSelect value={mode} onChange={setMode} />
+            <ChannelToggle value={channel} onChange={setChannel} />
+            <div style={{ flex: 1 }} />
+            <button
+              onClick={() => setModalOpen(true)}
+              title="View & edit the prompts sent to Claude"
+              style={{
+                border: `1px solid ${C.border}`,
+                background: "transparent",
+                color: C.textDim,
+                borderRadius: 999,
+                padding: "6px 12px",
+                fontSize: 12,
+                cursor: "pointer",
+                fontFamily: MONO,
+              }}
+            >
+              ✎ edit prompts
+            </button>
+          </div>
+
+          <div
+            className="chris-editor-wrap"
+            style={{
+              background: C.card,
+              border: `1px solid ${C.border}`,
+              borderRadius: 14,
+              padding: "20px 22px 8px",
+              minHeight: 168,
+            }}
+          >
+            <IMWEditor
+              key={editorKey}
+              placeholder="Just get it out — write the message however it comes. We'll smooth how it lands."
+              fontSize={16}
+              lineWidth="100%"
+              onChange={setDraftContent}
+              autoFocus={false}
+            />
+          </div>
+
+          <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "12px 4px 0" }}>
+            <div style={{ flex: 1 }} />
+            <button
+              onClick={handleSaveDraft}
+              disabled={draftEmpty || busy}
+              style={{
+                border: `1px solid ${C.border}`,
+                borderRadius: 10,
+                background: "transparent",
+                color: draftEmpty || busy ? C.textFaint : C.textDim,
+                fontSize: 13.5,
+                padding: "9px 14px",
+                cursor: draftEmpty || busy ? "default" : "pointer",
+                fontFamily: MONO,
+              }}
+            >
+              save draft
+            </button>
+            <button
+              onClick={handleGetSuggestion}
+              disabled={draftEmpty || busy}
+              style={{
+                border: "none",
+                borderRadius: 10,
+                background: draftEmpty || busy ? C.border : C.accent,
+                color: draftEmpty || busy ? C.textFaint : C.accentText,
+                fontWeight: 600,
+                fontSize: 14,
+                padding: "10px 18px",
+                cursor: draftEmpty || busy ? "default" : "pointer",
+              }}
+            >
+              {busy ? "thinking…" : "Get suggestion →"}
+            </button>
+          </div>
+
+          {/* Filters */}
+          <div
+            style={{
+              display: "flex",
+              flexWrap: "wrap",
+              alignItems: "center",
+              gap: 10,
+              padding: "16px 4px 0",
+            }}
+          >
+            <FilterSelect
+              value={channelFilter}
+              onChange={setChannelFilter}
+              options={[
+                { value: ALL_CHANNELS, label: "All Channels" },
+                ...CHANNELS.map((c) => ({ value: c.value, label: c.label })),
+              ]}
+            />
+            <FilterSelect
+              value={statusFilter}
+              onChange={setStatusFilter}
+              color={
+                statusFilter === ALL_STATUSES
+                  ? C.text
+                  : statusInfo(statusFilter as Status).color
+              }
+              options={[
+                { value: ALL_STATUSES, label: "All Stages" },
+                ...STATUSES.map((s) => ({ value: s.value, label: s.label })),
+              ]}
+            />
+          </div>
+        </section>
+      )}
+
+      {/* Feed */}
+      <section style={{ marginTop: editingId === null ? 30 : 28 }}>
+        {loading ? (
+          <p style={{ color: C.textFaint, fontFamily: MONO, fontSize: 13 }}>loading…</p>
+        ) : filtered.length === 0 ? (
+          <div style={{ textAlign: "center", padding: "48px 0", color: C.textFaint }}>
+            <p style={{ margin: 0, fontSize: 14 }}>
+              No messages yet. Draft one above and get a suggestion.
+            </p>
+          </div>
+        ) : (
+          <MessageFeed
+            messages={filtered}
+            editingId={editingId}
+            modeLabel={MODES.find((m) => m.value === mode)?.label ?? ""}
+            onEdit={expandEdit}
+            onCancelEdit={collapseEdit}
+            onTranslate={translate}
+            onPatch={patchMessage}
+            onDelete={deleteMessage}
+            applyReorder={(orderedIds) => {
+              setMessages((prev) => {
+                const inOrder = orderedIds
+                  .map((id) => prev.find((m) => m.id === id)!)
+                  .filter(Boolean);
+                const others = prev.filter((m) => !orderedIds.includes(m.id));
+                return [...inOrder, ...others];
+              });
+              void fetch("/chris/api/messages/reorder", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ ids: orderedIds }),
+              });
+            }}
+          />
+        )}
+      </section>
+
+      {modalOpen && (
+        <PromptModal
+          presets={presets}
+          activeMode={mode}
+          onSave={(id, prompt) => savePreset(id, { prompt })}
+          onReset={(id) => savePreset(id, { reset: true })}
+          onClose={() => setModalOpen(false)}
+        />
+      )}
+    </main>
+  );
+}
+
+// ── Mode select (persona picker) ─────────────────────────────────────────────
+
+function ModeSelect({ value, onChange }: { value: Mode; onChange: (m: Mode) => void }) {
+  const active = MODES.find((m) => m.value === value);
+  return (
+    <label
+      title={active?.blurb}
+      style={{ display: "inline-flex", alignItems: "center", gap: 7 }}
+    >
+      <span style={{ fontFamily: MONO, fontSize: 11, color: C.textFaint }}>mode</span>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value as Mode)}
+        style={{
+          background: C.card,
+          border: `1px solid ${C.accent}66`,
+          borderRadius: 999,
+          color: C.accent,
+          fontSize: 13,
+          fontFamily: MONO,
+          fontWeight: 600,
+          padding: "6px 30px 6px 13px",
+          cursor: "pointer",
+          outline: "none",
+          appearance: "none",
+          backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='%23c9a86a'/%3E%3C/svg%3E")`,
+          backgroundRepeat: "no-repeat",
+          backgroundPosition: "right 12px center",
+        }}
+      >
+        {MODES.map((m) => (
+          <option key={m.value} value={m.value}>
+            {m.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+// ── Prompt editor modal ──────────────────────────────────────────────────────
+
+function PromptModal({
+  presets,
+  activeMode,
+  onSave,
+  onReset,
+  onClose,
+}: {
+  presets: Preset[];
+  activeMode: Mode;
+  onSave: (id: string, prompt: string) => Promise<Preset | null>;
+  onReset: (id: string) => Promise<Preset | null>;
+  onClose: () => void;
+}) {
+  // Which mode's prompt is being viewed in the modal (starts on the active one).
+  const [tab, setTab] = useState<Mode>(activeMode);
+  const current = useMemo(
+    () => presets.find((p) => p.key === tab) ?? null,
+    [presets, tab]
+  );
+  const [draft, setDraft] = useState(current?.prompt ?? "");
+  const [savedFlash, setSavedFlash] = useState(false);
+  const [working, setWorking] = useState(false);
+
+  // Re-seed the textarea whenever the tab (or its stored prompt) changes.
+  useEffect(() => {
+    setDraft(current?.prompt ?? "");
+  }, [current?.id, current?.prompt]);
+
+  // Close on Escape.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const dirty = current ? draft !== current.prompt : false;
+  const modeMeta = MODES.find((m) => m.value === tab);
+
+  const flash = () => {
+    setSavedFlash(true);
+    setTimeout(() => setSavedFlash(false), 1400);
+  };
+
+  const handleSave = async () => {
+    if (!current || !dirty || working) return;
+    setWorking(true);
+    try {
+      const updated = await onSave(current.id, draft);
+      if (updated) flash();
+    } finally {
+      setWorking(false);
+    }
+  };
+
+  const handleReset = async () => {
+    if (!current || working) return;
+    setWorking(true);
+    try {
+      const updated = await onReset(current.id);
+      if (updated) {
+        setDraft(updated.prompt);
+        flash();
+      }
+    } finally {
+      setWorking(false);
+    }
+  };
+
+  return (
+    <div
+      onMouseDown={onClose}
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(0,0,0,0.6)",
+        display: "grid",
+        placeItems: "center",
+        padding: 24,
+        zIndex: 100,
+      }}
+    >
+      <div
+        onMouseDown={(e) => e.stopPropagation()}
+        style={{
+          width: "min(680px, 100%)",
+          maxHeight: "88vh",
+          display: "flex",
+          flexDirection: "column",
+          background: C.card,
+          border: `1px solid ${C.border}`,
+          borderRadius: 16,
+          overflow: "hidden",
+          boxShadow: "0 24px 64px rgba(0,0,0,0.5)",
+        }}
+      >
+        {/* Header */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            padding: "16px 18px",
+            borderBottom: `1px solid ${C.border}`,
+          }}
+        >
+          <span style={{ fontSize: 15, fontWeight: 600, color: C.text }}>
+            Translation prompts
+          </span>
+          <span style={{ fontFamily: MONO, fontSize: 11, color: C.textFaint }}>
+            sent to Claude with your draft
+          </span>
+          <div style={{ flex: 1 }} />
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            style={{
+              border: "none",
+              background: "transparent",
+              color: C.textDim,
+              cursor: "pointer",
+              fontSize: 18,
+              lineHeight: 1,
+              padding: 4,
+            }}
+          >
+            ×
+          </button>
+        </div>
+
+        {/* Mode tabs */}
+        <div style={{ display: "flex", gap: 6, padding: "12px 18px 0" }}>
+          {MODES.map((m) => {
+            const on = m.value === tab;
+            return (
+              <button
+                key={m.value}
+                onClick={() => setTab(m.value)}
+                style={{
+                  border: `1px solid ${on ? C.accent : C.border}`,
+                  background: on ? `${C.accent}1a` : "transparent",
+                  color: on ? C.accent : C.textDim,
+                  borderRadius: 999,
+                  padding: "6px 14px",
+                  fontSize: 12.5,
+                  fontFamily: MONO,
+                  fontWeight: on ? 600 : 400,
+                  cursor: "pointer",
+                }}
+              >
+                {m.label}
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Body */}
+        <div style={{ padding: "12px 18px 0", overflowY: "auto" }}>
+          <p style={{ margin: "4px 0 10px", fontSize: 12.5, color: C.textFaint, lineHeight: 1.5 }}>
+            {modeMeta?.blurb}. This text is the system prompt sent with your draft.
+            The selected channel (Slack / Email / Text) is appended as a short delivery-medium note.
+          </p>
+          <textarea
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            spellCheck={false}
+            style={{
+              width: "100%",
+              minHeight: 280,
+              resize: "vertical",
+              background: C.bg,
+              border: `1px solid ${C.border}`,
+              borderRadius: 10,
+              color: C.text,
+              fontFamily: MONO,
+              fontSize: 12.5,
+              lineHeight: 1.6,
+              padding: "12px 14px",
+              outline: "none",
+            }}
+          />
+        </div>
+
+        {/* Footer actions */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            padding: "14px 18px",
+          }}
+        >
+          <button
+            onClick={handleReset}
+            disabled={working}
+            style={{
+              border: `1px solid ${C.border}`,
+              background: "transparent",
+              color: C.textDim,
+              borderRadius: 10,
+              padding: "8px 14px",
+              fontSize: 12.5,
+              fontFamily: MONO,
+              cursor: working ? "default" : "pointer",
+            }}
+          >
+            reset to default
+          </button>
+          <span
+            style={{
+              fontFamily: MONO,
+              fontSize: 11.5,
+              color: savedFlash ? C.suggest : C.textFaint,
+            }}
+          >
+            {savedFlash ? "saved ✓" : dirty ? "unsaved changes" : ""}
+          </span>
+          <div style={{ flex: 1 }} />
+          <button
+            onClick={onClose}
+            style={{
+              border: "none",
+              background: "transparent",
+              color: C.textDim,
+              cursor: "pointer",
+              fontFamily: MONO,
+              fontSize: 12.5,
+              padding: "8px 10px",
+            }}
+          >
+            close
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={!dirty || working}
+            style={{
+              border: "none",
+              borderRadius: 10,
+              background: !dirty || working ? C.border : C.accent,
+              color: !dirty || working ? C.textFaint : C.accentText,
+              fontWeight: 600,
+              fontSize: 13,
+              padding: "8px 18px",
+              cursor: !dirty || working ? "default" : "pointer",
+            }}
+          >
+            {working ? "saving…" : "Save prompt"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Filter select (matches prompts styling) ──────────────────────────────────
+
+function FilterSelect({
+  value,
+  onChange,
+  options,
+  color = C.text,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  options: { value: string; label: string }[];
+  color?: string;
+}) {
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      style={{
+        background: C.card,
+        border: `1px solid ${C.border}`,
+        borderRadius: 8,
+        color,
+        fontSize: 12.5,
+        fontFamily: MONO,
+        padding: "6px 28px 6px 10px",
+        cursor: "pointer",
+        outline: "none",
+        appearance: "none",
+        backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='%236b7280'/%3E%3C/svg%3E")`,
+        backgroundRepeat: "no-repeat",
+        backgroundPosition: "right 10px center",
+      }}
+    >
+      {options.map((o) => (
+        <option key={o.value} value={o.value}>
+          {o.label}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+// ── Feed ─────────────────────────────────────────────────────────────────────
+
+function MessageFeed({
+  messages,
+  editingId,
+  modeLabel,
+  onEdit,
+  onCancelEdit,
+  onTranslate,
+  onPatch,
+  onDelete,
+  applyReorder,
+}: {
+  messages: Message[];
+  editingId: string | null;
+  modeLabel: string;
+  onEdit: (id: string) => void;
+  onCancelEdit: () => void;
+  onTranslate: (id: string, channel: Channel, draftOverride?: string) => Promise<Message | null>;
+  onPatch: (
+    id: string,
+    body: { draft?: string; finalDraft?: string | null; channel?: Channel; status?: Status }
+  ) => Promise<Message | null>;
+  onDelete: (id: string) => void;
+  applyReorder: (orderedIds: string[]) => void;
+}) {
+  const { rowProps, rowStyle } = useDragReorder(messages, (next) =>
+    applyReorder(next.map((m) => m.id))
+  );
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+      {messages.map((m) =>
+        editingId === m.id ? (
+          <MessageWorkspace
+            key={m.id}
+            message={m}
+            modeLabel={modeLabel}
+            onTranslate={onTranslate}
+            onPatch={onPatch}
+            onClose={onCancelEdit}
+            onDelete={() => {
+              onDelete(m.id);
+              onCancelEdit();
+            }}
+          />
+        ) : (
+          <MessageRow
+            key={m.id}
+            message={m}
+            dragProps={rowProps(m.id)}
+            dragStyle={rowStyle(m.id)}
+            onOpen={() => onEdit(m.id)}
+            onDelete={() => onDelete(m.id)}
+          />
+        )
+      )}
+    </div>
+  );
+}
+
+// ── Collapsed row ────────────────────────────────────────────────────────────
+
+function MessageRow({
+  message,
+  dragProps,
+  dragStyle,
+  onOpen,
+  onDelete,
+}: {
+  message: Message;
+  dragProps: React.HTMLAttributes<HTMLDivElement> & { draggable?: boolean };
+  dragStyle: React.CSSProperties;
+  onOpen: () => void;
+  onDelete: () => void;
+}) {
+  const [hover, setHover] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const si = statusInfo(message.status);
+  const channelLabel = CHANNELS.find((c) => c.value === message.channel)?.label ?? message.channel;
+
+  // Show the most advanced stage available.
+  const { label: stageLabel, text } = useMemo(() => {
+    if (message.finalDraft && !isJSONEmpty(message.finalDraft))
+      return { label: "final draft", text: previewJSON(message.finalDraft, 200) };
+    if (message.response) return { label: "suggested", text: message.response.slice(0, 200) };
+    return { label: "your draft", text: previewJSON(message.draft, 200) };
+  }, [message]);
+
+  const copyText = useMemo(() => {
+    if (message.finalDraft && !isJSONEmpty(message.finalDraft)) return previewJSON(message.finalDraft, 10000);
+    if (message.response) return message.response;
+    return previewJSON(message.draft, 10000);
+  }, [message]);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(copyText);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1200);
+    } catch {
+      /* ignore */
+    }
+  };
+
+  return (
+    <div
+      {...dragProps}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      style={{
+        position: "relative",
+        border: `1px solid ${C.border}`,
+        borderRadius: 12,
+        background: hover ? C.cardHover : C.card,
+        padding: "14px 16px",
+        transition: "background 0.12s ease",
+        viewTransitionName: `message-${message.id}`,
+        ...dragStyle,
+      } as React.CSSProperties}
+    >
+      {/* Header chips */}
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 9 }}>
+        <span
+          style={{
+            fontFamily: MONO,
+            fontSize: 11,
+            color: C.textDim,
+            border: `1px solid ${C.border}`,
+            borderRadius: 999,
+            padding: "2px 9px",
+          }}
+        >
+          {channelLabel}
+        </span>
+        <span
+          style={{
+            fontSize: 11,
+            fontFamily: MONO,
+            color: si.color,
+            border: `1px solid ${si.color}44`,
+            background: `${si.color}15`,
+            borderRadius: 999,
+            padding: "2px 9px",
+          }}
+        >
+          {si.label}
+        </span>
+        <div style={{ flex: 1 }} />
+        <span style={{ fontFamily: MONO, fontSize: 11, color: C.textFaint }}>
+          {formatRelative(message.updatedAt)}
+        </span>
+      </div>
+
+      {/* Body */}
+      <div onClick={onOpen} title="Open workspace" style={{ cursor: "pointer" }}>
+        <span
+          style={{
+            fontFamily: MONO,
+            fontSize: 10,
+            letterSpacing: "0.06em",
+            textTransform: "uppercase",
+            color: C.textFaint,
+          }}
+        >
+          {stageLabel}
+        </span>
+        <div
+          style={{
+            fontSize: 14,
+            lineHeight: 1.55,
+            color: C.text,
+            marginTop: 4,
+            wordBreak: "break-word",
+          }}
+        >
+          {text}
+          {text.length >= 200 && <span style={{ color: C.textFaint }}> …</span>}
+        </div>
+      </div>
+
+      {/* Footer actions */}
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 12 }}>
+        <button
+          onClick={onOpen}
+          style={{
+            border: `1px solid ${C.border}`,
+            background: "transparent",
+            color: C.textDim,
+            borderRadius: 999,
+            padding: "4px 12px",
+            fontSize: 12,
+            cursor: "pointer",
+            fontFamily: MONO,
+          }}
+        >
+          open →
+        </button>
+        <div style={{ flex: 1 }} />
+        <button
+          onClick={handleCopy}
+          style={{
+            border: "none",
+            background: "transparent",
+            color: copied ? C.accent : C.textFaint,
+            cursor: "pointer",
+            fontFamily: MONO,
+            fontSize: 11.5,
+            padding: "3px 6px",
+            opacity: hover || copied ? 1 : 0.6,
+          }}
+        >
+          {copied ? "copied ✓" : "copy"}
+        </button>
+        <button
+          onClick={onDelete}
+          aria-label="Delete"
+          style={{
+            border: "none",
+            background: "transparent",
+            color: C.textFaint,
+            cursor: "pointer",
+            fontSize: 14,
+            lineHeight: 1,
+            padding: "3px 4px",
+            opacity: hover ? 1 : 0,
+            transition: "opacity 0.12s ease",
+          }}
+        >
+          ×
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── Expanded workspace — the draft → suggestion → final-draft flow ───────────
+
+function StepHeader({ n, label, color }: { n: number; label: string; color: string }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 10 }}>
+      <span
+        style={{
+          width: 22,
+          height: 22,
+          borderRadius: 999,
+          display: "grid",
+          placeItems: "center",
+          fontFamily: MONO,
+          fontSize: 11.5,
+          fontWeight: 600,
+          color: C.bg,
+          background: color,
+        }}
+      >
+        {n}
+      </span>
+      <span style={{ fontSize: 13.5, fontWeight: 600, color: C.text }}>{label}</span>
+    </div>
+  );
+}
+
+function MessageWorkspace({
+  message,
+  modeLabel,
+  onTranslate,
+  onPatch,
+  onClose,
+  onDelete,
+}: {
+  message: Message;
+  modeLabel: string;
+  onTranslate: (id: string, channel: Channel, draftOverride?: string) => Promise<Message | null>;
+  onPatch: (
+    id: string,
+    body: { draft?: string; finalDraft?: string | null; channel?: Channel; status?: Status }
+  ) => Promise<Message | null>;
+  onClose: () => void;
+  onDelete: () => void;
+}) {
+  const [channel, setChannel] = useState<Channel>(message.channel);
+  const [draft, setDraft] = useState(message.draft);
+  const [response, setResponse] = useState<string | null>(message.response);
+
+  // Final-draft editor is seeded from finalDraft, or from the suggestion when
+  // the writer clicks "Use as final draft". Remount via key to re-seed.
+  const [finalSeed, setFinalSeed] = useState(message.finalDraft ?? "");
+  const [finalContent, setFinalContent] = useState(message.finalDraft ?? "");
+  const [finalKey, setFinalKey] = useState(0);
+
+  const [translating, setTranslating] = useState(false);
+  const [savingFinal, setSavingFinal] = useState(false);
+  const [respCopied, setRespCopied] = useState(false);
+  const [finalCopied, setFinalCopied] = useState(false);
+
+  const draftDirty = draft !== message.draft || channel !== message.channel;
+
+  const runTranslate = async () => {
+    setTranslating(true);
+    try {
+      const updated = await onTranslate(message.id, channel, draftDirty ? draft : undefined);
+      if (updated) setResponse(updated.response);
+    } finally {
+      setTranslating(false);
+    }
+  };
+
+  const useAsFinal = () => {
+    if (!response) return;
+    setFinalSeed(response);
+    setFinalContent(response);
+    setFinalKey((k) => k + 1);
+  };
+
+  const saveFinal = async () => {
+    setSavingFinal(true);
+    try {
+      await onPatch(message.id, { draft, finalDraft: finalContent, channel });
+      onClose();
+    } finally {
+      setSavingFinal(false);
+    }
+  };
+
+  const copy = async (text: string, which: "resp" | "final") => {
+    try {
+      await navigator.clipboard.writeText(text);
+      if (which === "resp") {
+        setRespCopied(true);
+        setTimeout(() => setRespCopied(false), 1200);
+      } else {
+        setFinalCopied(true);
+        setTimeout(() => setFinalCopied(false), 1200);
+      }
+    } catch {
+      /* ignore */
+    }
+  };
+
+  const responseParas = useMemo(
+    () => (response ?? "").split(/\n{2,}/).map((p) => p.trim()).filter(Boolean),
+    [response]
+  );
+  const finalEmpty = isJSONEmpty(finalContent);
+
+  return (
+    <div
+      className="chris-editor-wrap"
+      style={{
+        position: "relative",
+        background: C.card,
+        border: `1px solid ${C.accent}55`,
+        borderRadius: 14,
+        padding: "18px 20px 16px",
+        viewTransitionName: `message-${message.id}`,
+      } as React.CSSProperties}
+    >
+      {/* Top bar: channel + close */}
+      <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 16 }}>
+        <ChannelToggle value={channel} onChange={setChannel} size="sm" />
+        <div style={{ flex: 1 }} />
+        <button
+          onClick={onDelete}
+          style={{
+            border: "none",
+            background: "transparent",
+            color: C.danger,
+            cursor: "pointer",
+            fontFamily: MONO,
+            fontSize: 12,
+            padding: "4px 8px",
+          }}
+        >
+          delete
+        </button>
+        <button
+          onClick={onClose}
+          style={{
+            border: "none",
+            background: "transparent",
+            color: C.textDim,
+            cursor: "pointer",
+            fontFamily: MONO,
+            fontSize: 12,
+            padding: "4px 8px",
+          }}
+        >
+          close
+        </button>
+      </div>
+
+      {/* Step 1 — Your draft */}
+      <section style={{ marginBottom: 22 }}>
+        <StepHeader n={1} label="Your draft" color={C.textDim} />
+        <div
+          style={{
+            background: C.bg,
+            border: `1px solid ${C.border}`,
+            borderRadius: 12,
+            padding: "12px 14px 2px",
+          }}
+        >
+          <IMWEditor
+            key={`draft-${message.id}`}
+            initialContent={message.draft}
+            placeholder="Write it however it comes…"
+            fontSize={15}
+            lineWidth="100%"
+            onChange={setDraft}
+            autoFocus={false}
+          />
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 10 }}>
+          <span style={{ fontFamily: MONO, fontSize: 11, color: C.textFaint }}>
+            mode: <span style={{ color: C.accent }}>{modeLabel}</span>
+          </span>
+          <div style={{ flex: 1 }} />
+          <button
+            onClick={runTranslate}
+            disabled={translating || isJSONEmpty(draft)}
+            style={{
+              border: "none",
+              borderRadius: 10,
+              background: translating || isJSONEmpty(draft) ? C.border : C.suggest,
+              color: translating || isJSONEmpty(draft) ? C.textFaint : "#0a1420",
+              fontWeight: 600,
+              fontSize: 13,
+              padding: "8px 16px",
+              cursor: translating || isJSONEmpty(draft) ? "default" : "pointer",
+            }}
+          >
+            {translating ? "translating…" : response ? "Regenerate suggestion" : "Get suggestion →"}
+          </button>
+        </div>
+      </section>
+
+      {/* Step 2 — Suggested rewrite */}
+      <section style={{ marginBottom: 22 }}>
+        <StepHeader n={2} label="Suggested rewrite — how it'll land" color={C.suggest} />
+        {translating && !response ? (
+          <div
+            style={{
+              border: `1px solid ${C.border}`,
+              borderRadius: 12,
+              padding: "18px 16px",
+              color: C.textFaint,
+              fontFamily: MONO,
+              fontSize: 13,
+            }}
+          >
+            reading the room…
+          </div>
+        ) : response ? (
+          <div
+            style={{
+              border: `1px solid ${C.suggest}44`,
+              background: `${C.suggest}0d`,
+              borderRadius: 12,
+              padding: "14px 16px",
+            }}
+          >
+            {responseParas.map((p, i) => (
+              <p
+                key={i}
+                style={{
+                  margin: i === 0 ? 0 : "10px 0 0",
+                  fontSize: 14.5,
+                  lineHeight: 1.6,
+                  color: C.text,
+                  whiteSpace: "pre-wrap",
+                  wordBreak: "break-word",
+                }}
+              >
+                {p}
+              </p>
+            ))}
+            <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 14 }}>
+              <button
+                onClick={useAsFinal}
+                style={{
+                  border: "none",
+                  borderRadius: 10,
+                  background: C.accent,
+                  color: C.accentText,
+                  fontWeight: 600,
+                  fontSize: 12.5,
+                  padding: "7px 14px",
+                  cursor: "pointer",
+                }}
+              >
+                Use as final draft ↓
+              </button>
+              <div style={{ flex: 1 }} />
+              <button
+                onClick={() => copy(response, "resp")}
+                style={{
+                  border: "none",
+                  background: "transparent",
+                  color: respCopied ? C.accent : C.textFaint,
+                  cursor: "pointer",
+                  fontFamily: MONO,
+                  fontSize: 11.5,
+                  padding: "3px 6px",
+                }}
+              >
+                {respCopied ? "copied ✓" : "copy"}
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div
+            style={{
+              border: `1px dashed ${C.border}`,
+              borderRadius: 12,
+              padding: "16px",
+              color: C.textFaint,
+              fontSize: 13,
+            }}
+          >
+            Get a suggestion above and Claude&apos;s neurotypical-professional rewrite shows up here.
+          </div>
+        )}
+      </section>
+
+      {/* Step 3 — Final draft */}
+      <section>
+        <StepHeader n={3} label="Final draft — make it yours" color={C.accent} />
+        <div
+          style={{
+            background: C.bg,
+            border: `1px solid ${C.border}`,
+            borderRadius: 12,
+            padding: "12px 14px 2px",
+          }}
+        >
+          <IMWEditor
+            key={`final-${message.id}-${finalKey}`}
+            initialContent={finalSeed}
+            placeholder="Edit the suggestion into your own send-ready message…"
+            fontSize={15}
+            lineWidth="100%"
+            onChange={setFinalContent}
+            autoFocus={false}
+          />
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 10 }}>
+          <button
+            onClick={() => copy(previewJSON(finalContent, 10000), "final")}
+            disabled={finalEmpty}
+            style={{
+              border: `1px solid ${C.border}`,
+              background: "transparent",
+              color: finalEmpty ? C.textFaint : finalCopied ? C.accent : C.textDim,
+              borderRadius: 10,
+              padding: "8px 14px",
+              fontSize: 12.5,
+              cursor: finalEmpty ? "default" : "pointer",
+              fontFamily: MONO,
+            }}
+          >
+            {finalCopied ? "copied ✓" : "copy final"}
+          </button>
+          <div style={{ flex: 1 }} />
+          <button
+            onClick={saveFinal}
+            disabled={savingFinal}
+            style={{
+              border: "none",
+              borderRadius: 10,
+              background: C.accent,
+              color: C.accentText,
+              fontWeight: 600,
+              fontSize: 13,
+              padding: "8px 18px",
+              cursor: savingFinal ? "default" : "pointer",
+            }}
+          >
+            {savingFinal ? "saving…" : "Save"}
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/chris/page.tsx
+++ b/app/chris/page.tsx
@@ -24,7 +24,7 @@ const MODULES: Module[] = [
   { key: "journal", name: "Journal", blurb: "Write entries — shared with InMyWords", glyph: "✦", href: "/chris/journal" },
   { key: "shopping", name: "Shopping List", blurb: "Items grouped by retailer", glyph: "⟳", href: "/chris/shopping" },
   { key: "prompts", name: "Prompts", blurb: "Drafting space for LLM prompts", glyph: "✎", href: "/chris/prompts" },
-  { key: "automations", name: "Automations", blurb: "Little helpers & scripts", glyph: "⚙" },
+  { key: "messages", name: "Messaging", blurb: "Draft messages → tune how they land", glyph: "✉", href: "/chris/messages" },
 ];
 
 export default function PlaygroundHome() {

--- a/app/chris/prompts/page.tsx
+++ b/app/chris/prompts/page.tsx
@@ -201,6 +201,34 @@ export default function PromptsPage() {
       setPrompts((prev) => [prompt, ...prev]);
       setDraftContent("");
       setEditorKey((k) => k + 1);
+      // Auto-name in the background, claude.ai-style. Best-effort; never blocks.
+      if (!prompt.title) void autoNamePrompt(prompt.id);
+    }
+  };
+
+  // Ask Claude for a title based on the saved content, then persist it — but
+  // only if the user hasn't typed their own title in the meantime.
+  const autoNamePrompt = async (id: string) => {
+    try {
+      const res = await fetch(`/chris/api/prompts/${id}/generate-title`, {
+        method: "POST",
+      });
+      if (!res.ok) return;
+      const { title } = await res.json();
+      if (!title) return;
+
+      const patchRes = await fetch(`/chris/api/prompts/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title }),
+      });
+      if (!patchRes.ok) return;
+      const { prompt: updated } = await patchRes.json();
+      setPrompts((prev) =>
+        prev.map((p) => (p.id === id && !p.title ? updated : p))
+      );
+    } catch {
+      // best-effort — leave the prompt untitled on failure
     }
   };
 
@@ -540,8 +568,11 @@ export default function PromptsPage() {
                     });
                   }}
                   onPatchSave={async (id, data) => {
+                    const existing = prompts.find((p) => p.id === id);
                     await patchPrompt(id, data);
                     collapseEdit();
+                    // Re-name on content edits while still untitled.
+                    if (existing && !existing.title) void autoNamePrompt(id);
                   }}
                   onCancelEdit={collapseEdit}
                   onDelete={deletePrompt}
@@ -697,21 +728,33 @@ function PromptRow({
         ...dragStyle,
       } as React.CSSProperties}
     >
-      <div
-        onClick={onEdit}
-        title="Click to edit"
-        style={{
-          fontSize: 14,
-          lineHeight: 1.55,
-          color: C.text,
-          cursor: "pointer",
-          wordBreak: "break-word",
-        }}
-      >
-        {preview}
-        {prompt.content.length > 200 && (
-          <span style={{ color: C.textFaint }}> …</span>
+      <div onClick={onEdit} title="Click to edit" style={{ cursor: "pointer" }}>
+        {prompt.title && (
+          <div
+            style={{
+              fontSize: 14.5,
+              fontWeight: 600,
+              color: C.text,
+              marginBottom: 5,
+              wordBreak: "break-word",
+            }}
+          >
+            {prompt.title}
+          </div>
         )}
+        <div
+          style={{
+            fontSize: prompt.title ? 13 : 14,
+            lineHeight: 1.55,
+            color: prompt.title ? C.textDim : C.text,
+            wordBreak: "break-word",
+          }}
+        >
+          {preview}
+          {prompt.content.length > 200 && (
+            <span style={{ color: C.textFaint }}> …</span>
+          )}
+        </div>
       </div>
 
       <div

--- a/lib/generate-title.ts
+++ b/lib/generate-title.ts
@@ -1,0 +1,71 @@
+import { generateText } from "ai";
+import { anthropic, CLAUDE_MODEL } from "@/lib/ai";
+
+// Shared title-generation logic. Mirrors how the main journal auto-names entries
+// (claude.ai-style "name the session after enough context"). Server-side only —
+// never import into a client component (it reaches ANTHROPIC_API_KEY via lib/ai).
+
+export type TitleKind = "journal" | "prompt";
+
+// Minimum plain-text words before we bother asking Claude for a title. Saving is
+// an explicit action, so this just avoids naming near-empty drafts.
+export const MIN_TITLE_WORDS = 10;
+
+const JOURNAL_SYSTEM_PROMPT = `You are helping someone give a name to something they experienced and wrote about.
+
+They've written a journal entry about their life — often about hard moments, sensory experiences, emotional days, or things that were difficult to navigate. Your job is to read what they wrote and suggest a short, evocative title that feels true to their experience.
+
+The title should:
+- Be 8 words or fewer
+- Reflect what actually happened or what they felt — not a diagnostic label
+- Sound like something a thoughtful, caring friend might say, not a clinician
+- Capture the emotional truth or the specific moment
+- Use plain, human language — no jargon, no clinical framing
+- Feel personal and specific, not generic
+
+Return ONLY the title itself — no quotes, no punctuation at the end, nothing else.`;
+
+const PROMPT_SYSTEM_PROMPT = `You are naming a saved LLM prompt draft so it is easy to find in a list later.
+
+You'll be given the text of a prompt someone is writing — instructions, system context, examples, or a task they want a model to perform. Your job is to read it and produce a short, descriptive label for what the prompt does.
+
+The title should:
+- Be 8 words or fewer
+- Describe the prompt's purpose or task, not restate it verbatim
+- Be specific enough to tell similar prompts apart (mention the domain/output if clear)
+- Use plain, practical language — like a good file name, not marketing copy
+- Avoid quotes, trailing punctuation, and the word "prompt"
+
+Return ONLY the title itself — no quotes, no punctuation at the end, nothing else.`;
+
+export function countWords(text: string): number {
+  const trimmed = text.trim();
+  if (!trimmed) return 0;
+  return trimmed.split(/\s+/).length;
+}
+
+// Returns a generated title, or null if Claude came back empty. Callers are
+// responsible for deciding whether the content is substantial enough to name
+// (see MIN_TITLE_WORDS / countWords). Throws if the Anthropic call itself fails.
+export async function generateTitle(
+  content: string,
+  kind: TitleKind = "journal"
+): Promise<string | null> {
+  const system = kind === "prompt" ? PROMPT_SYSTEM_PROMPT : JOURNAL_SYSTEM_PROMPT;
+  const { text } = await generateText({
+    model: anthropic(CLAUDE_MODEL),
+    system,
+    prompt: content.trim(),
+    maxOutputTokens: 60,
+  });
+
+  // Claude occasionally wraps short replies in quotes/fences despite instructions.
+  const cleaned = text
+    .trim()
+    .replace(/^```(?:\w+)?\s*/i, "")
+    .replace(/\s*```$/, "")
+    .replace(/^["'`]+|["'`]+$/g, "")
+    .trim();
+
+  return cleaned || null;
+}

--- a/lib/reorder.ts
+++ b/lib/reorder.ts
@@ -9,6 +9,7 @@ type ReorderModel =
   | "shoppingList"
   | "project"
   | "prompt"
+  | "message"
   | "journalEntry";
 
 export async function reorderForUser(

--- a/lib/translate-message.ts
+++ b/lib/translate-message.ts
@@ -1,0 +1,133 @@
+import { generateText } from "ai";
+import { anthropic, CLAUDE_MODEL } from "@/lib/ai";
+
+// Messaging "translation": take the writer's rough draft and rewrite it so the
+// intended reader receives it the way the writer means it — fixing the HOW (how
+// it lands), not just the WHAT. The system prompt is chosen by "mode" (a persona
+// preset the owner can edit) and the prompt text is supplied by the caller from
+// the stored preset. Server-side only.
+
+// ── Channel (delivery medium) ────────────────────────────────────────────────
+
+export type MessageChannel = "slack" | "email" | "text";
+
+export const MESSAGE_CHANNELS: { value: MessageChannel; label: string }[] = [
+  { value: "slack", label: "Slack" },
+  { value: "email", label: "Email" },
+  { value: "text", label: "Text" },
+];
+
+export function isMessageChannel(v: unknown): v is MessageChannel {
+  return v === "slack" || v === "email" || v === "text";
+}
+
+// A short, transparent note appended to whichever preset prompt is active so the
+// rewrite respects the delivery medium. (Shown to the owner in the edit modal.)
+const CHANNEL_MEDIUM_NOTE: Record<MessageChannel, string> = {
+  email:
+    "This will be sent as an email — a brief greeting and sign-off are appropriate, and the main point should survive a skim.",
+  slack:
+    "This will be sent over Slack — no greeting or sign-off; keep it concise and direct.",
+  text:
+    "This will be sent as a text / DM — brief and human; no greeting or sign-off; no emoji.",
+};
+
+// ── Modes (editable persona presets) ─────────────────────────────────────────
+
+export type MessageMode = "professional" | "dating" | "friends";
+
+export const MESSAGE_MODES: { value: MessageMode; label: string; blurb: string }[] = [
+  {
+    value: "professional",
+    label: "Professional",
+    blurb: "Neurodivergent → neurotypical, educated professional workplace",
+  },
+  {
+    value: "dating",
+    label: "Dating",
+    blurb: "Messages to women on dating apps",
+  },
+  {
+    value: "friends",
+    label: "Friends",
+    blurb: "Casual messages to friends",
+  },
+];
+
+export function isMessageMode(v: unknown): v is MessageMode {
+  return v === "professional" || v === "dating" || v === "friends";
+}
+
+// Default prompt text per mode. Used to seed the owner's editable presets and as
+// the "reset to default" target. Owners can edit these freely in the UI.
+export const DEFAULT_MODE_PROMPTS: Record<MessageMode, string> = {
+  professional: `You are helping a neurodivergent writer adapt a message so it lands well with a neurotypical reader in an educated, professional workplace.
+
+Rewrite the draft so a neurotypical, top-down-processing reader receives it the way the writer intends — fixing not just WHAT is said but HOW it is received.
+
+Neurotypical readers process top-down: they form an impression from the overall framing first, then fill in the details. So:
+- Lead with the headline — the ask, decision, or main point — then give the context underneath.
+- Make implicit social signals explicit: a brief acknowledgment, a reason for a request, or a clear next step where a neurotypical reader would expect one and feel its absence.
+- Soften phrasing that could read as blunt, abrupt, cold, or demanding — without changing the substance, hedging the point, or adding flattery.
+- Remove ambiguity about what you need and by when.
+- Keep it tight.
+
+Do NOT add small talk, colloquialisms, filler, or emoji. Preserve the writer's meaning, facts, and intent exactly; never invent details. Keep their authentic voice — smooth the social-pragmatic edges, don't replace the person.
+
+Return ONLY the rewritten message, ready to send. No preamble, no explanation, no surrounding quotes.`,
+
+  dating: `You are helping the writer adapt a message they're sending to a woman on a dating app, so it comes across the way they actually intend.
+
+Rewrite the draft so it reads as warm, genuine, and confident — emotionally attuned to how she'll receive it, not just what it literally says.
+
+- Keep it relaxed and human; lead with genuine interest or a specific hook from the conversation.
+- Make warmth and intent clear without coming across as intense, needy, or over-eager.
+- Soften anything that could read as blunt, transactional, or socially off, and add the light social warmth a typical reader expects.
+- Stay respectful and never presumptuous — no pressure, no negging, no clichés or pickup-artist lines.
+- Match her energy and keep it reasonably short.
+
+Preserve the writer's real meaning and personality; never invent facts about them or her. Keep their authentic voice — smooth the delivery, don't fake a persona.
+
+Return ONLY the rewritten message. No preamble, no explanation, no surrounding quotes.`,
+
+  friends: `You are helping the writer adapt a casual message to a friend so it lands warmly and clearly.
+
+Rewrite the draft so it reads as relaxed, friendly, and easy to receive — matching how a friend will read the tone, not just the literal words.
+
+- Keep it casual and warm; contractions and a light tone are good.
+- Soften anything that could accidentally read as blunt, cold, or overly literal/formal.
+- Make implicit warmth explicit where a friend would expect it — a bit of acknowledgment, enthusiasm, or care.
+- Keep their actual point and plans exactly intact; don't add fake hype or filler.
+- Brief is fine.
+
+Preserve the writer's meaning and voice; never invent details. Smooth the delivery, keep it them.
+
+Return ONLY the rewritten message. No preamble, no explanation, no surrounding quotes.`,
+};
+
+// ── Translation ──────────────────────────────────────────────────────────────
+
+export async function translateMessage(
+  draftPlainText: string,
+  channel: MessageChannel,
+  systemPromptBase: string
+): Promise<string> {
+  const base = (systemPromptBase || "").trim() || DEFAULT_MODE_PROMPTS.professional;
+  const system = `${base}\n\nDelivery medium: ${CHANNEL_MEDIUM_NOTE[channel]}`;
+
+  const { text } = await generateText({
+    model: anthropic(CLAUDE_MODEL),
+    system,
+    prompt: draftPlainText.trim(),
+    maxOutputTokens: 700,
+  });
+
+  // Strip stray wrapping quotes/fences Claude occasionally adds. Leave internal
+  // formatting intact.
+  return text
+    .trim()
+    .replace(/^```(?:\w+)?\s*/i, "")
+    .replace(/\s*```$/, "")
+    .replace(/^["“']+|["”']+$/g, "")
+    .trim();
+}

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -11,5 +11,10 @@ export default defineConfig({
   },
   datasource: {
     url: process.env["DATABASE_URL"]!,
+    // Shadow DB is only needed for `prisma migrate dev` / `migrate diff
+    // --from-migrations`. Neon's pooled connection can't CREATE DATABASE, so
+    // point this at a throwaway Postgres (local or a separate Neon db) when you
+    // run those commands. Unset in normal app runtime. See CLAUDE.md.
+    shadowDatabaseUrl: process.env["SHADOW_DATABASE_URL"],
   },
 });

--- a/prisma/migrations/20260602184246_add_prompt_status_and_messaging/migration.sql
+++ b/prisma/migrations/20260602184246_add_prompt_status_and_messaging/migration.sql
@@ -1,0 +1,27 @@
+-- Baseline catch-up: these changes were previously applied to the live database
+-- with `prisma db push` and are being folded back into migration history so the
+-- migrations directory once again reproduces the live schema. This migration is
+-- recorded as already-applied (via `prisma migrate resolve --applied`); the SQL
+-- below is for fresh databases / shadow replays only.
+
+-- AlterTable
+ALTER TABLE "Prompt" ADD COLUMN     "status" TEXT NOT NULL DEFAULT 'draft';
+
+-- CreateTable
+CREATE TABLE "Message" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "channel" TEXT NOT NULL DEFAULT 'email',
+    "draft" TEXT NOT NULL,
+    "response" TEXT,
+    "finalDraft" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'draft',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Message_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Message_userId_idx" ON "Message"("userId");

--- a/prisma/migrations/20260602235311_add_message_presets/migration.sql
+++ b/prisma/migrations/20260602235311_add_message_presets/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "MessagePreset" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+    "prompt" TEXT NOT NULL,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MessagePreset_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "MessagePreset_userId_idx" ON "MessagePreset"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MessagePreset_userId_key_key" ON "MessagePreset"("userId", "key");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -105,6 +105,45 @@ model Prompt {
   @@index([projectId])
 }
 
+// Playground Messaging — drafts of Slack/email/text messages that Claude
+// "translates" into a neurotypical-professional register, then the writer edits
+// into a final draft. Three stages: draft → response → finalDraft.
+//   - draft:      the writer's raw message (TipTap JSON)
+//   - response:   Claude's suggested rewrite (plain text)
+//   - finalDraft: the writer's edited, send-ready version (TipTap JSON)
+model Message {
+  id         String   @id @default(cuid())
+  userId     String
+  sortOrder  Int      @default(0)
+  channel    String   @default("email") // "slack" | "email" | "text"
+  draft      String   // TipTap JSON
+  response   String?  // plain text from Claude
+  finalDraft String?  // TipTap JSON
+  status     String   @default("draft") // "draft" | "response" | "final"
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+
+  @@index([userId])
+}
+
+// Editable persona presets for Messaging translation. One row per (user, key);
+// `key` is a stable MessageMode ("professional" | "dating" | "friends"). `prompt`
+// is the system prompt the owner can edit in the UI. Seeded from defaults in
+// lib/translate-message.ts on first load.
+model MessagePreset {
+  id        String   @id @default(cuid())
+  userId    String
+  key       String
+  label     String
+  prompt    String
+  sortOrder Int      @default(0)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([userId, key])
+  @@index([userId])
+}
+
 // Shopping lists — playground module. Each list is typically a retailer
 // (Target, Walmart, Amazon, etc.). Items belong to exactly one list.
 model ShoppingList {


### PR DESCRIPTION
## Summary
Playground (`/chris`) work from this session, all owner-gated.

- **Messaging** (`/chris/messages`): a `draft → response → final-draft` flow that rewrites a message for *how it lands*, not just what it says. New `Message` model + CRUD/translate/reorder routes. Replaces the Automations stub card on the landing page.
- **Editable persona presets**: `MessagePreset` model seeded with three modes — **professional / dating / friends**. A mode dropdown picks the active voice; an "edit prompts" modal exposes the exact system prompt per mode with save + reset-to-default. The translate route loads the chosen mode's stored prompt.
- **AI auto-naming**: shared `lib/generate-title.ts` powers title generation for prompts and the playground journal (mirrors the main journal), via owner-gated `/chris` generate-title routes.

## Migrations
- Re-baselined earlier `db push` drift into proper history (`add_prompt_status_and_messaging`, marked applied — **no data loss**).
- `add_message_presets` created via the restored `migrate dev` workflow.
- `prisma.config.ts` gains an env-driven `shadowDatabaseUrl` so `migrate dev` works against Neon.

## Verification
- `tsc --noEmit` + `eslint` clean.
- Full flows exercised in preview: draft→translate→final-draft persistence, channel- and mode-specific output, preset seed/edit/persist/reset. Test data cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)